### PR TITLE
Updating with language from the design

### DIFF
--- a/app/common/lib/index.js
+++ b/app/common/lib/index.js
@@ -19,7 +19,7 @@ const fetchJSON = async path => {
 /**
  * fetchStxAddressDetails
  *
- * Fetches data for a stacks address from the Blockstack Explorer API
+ * Fetches data for a Stacks address from the Blockstack Explorer API
  * Contains data about allocations and confirmed stx tx's
  *
  * @param {String} address - the Stacks address

--- a/app/components/field/index.js
+++ b/app/components/field/index.js
@@ -155,7 +155,7 @@ const BalanceField = connect(mapStateToProps)(({ balance, pendingBalance }) => {
   return (
     <Flex flexDirection={"column"} flexShrink={0} pb={5}>
       <Type pb={2} fontWeight={500} fontSize={1} is="label">
-        Available to Send
+        Available to send
       </Type>
       <Flex
         border={1}
@@ -165,7 +165,7 @@ const BalanceField = connect(mapStateToProps)(({ balance, pendingBalance }) => {
         overflow="hidden"
       >
         <Flex px={3} height={48} flexGrow={1} alignItems="center">
-          Stacks Balance
+          Stacks balance
         </Flex>
         <Flex
           alignItems="center"

--- a/app/components/loading/index.js
+++ b/app/components/loading/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Flex, Type, Input, Buttons } from "blockstack-ui/dist";
 import { Spinner } from "@components/spinner";
 
-const Loading = ({ message = "Fetching Wallet Details...", ...rest }) => (
+const Loading = ({ message = "Fetching wallet details...", ...rest }) => (
   <Flex
     position="absolute"
     width="100%"

--- a/app/components/transaction-list/index.js
+++ b/app/components/transaction-list/index.js
@@ -15,7 +15,7 @@ import {
 
 const Empty = ({ isFetching, ...rest }) => {
   const Icon = isFetching ? Spinner : LayersOffOutlineIcon;
-  const message = isFetching ? "Loading..." : "No Transaction History";
+  const message = isFetching ? "Loading..." : "No transactions found for this address.";
   return (
     <Flex
       flexGrow={1}

--- a/app/containers/balance/index.js
+++ b/app/containers/balance/index.js
@@ -67,7 +67,7 @@ const BalanceSection = connect(state => ({
                   color={state.view === "balance" ? "blue.dark" : undefined}
                   cursor="pointer"
                 >
-                  Wallet Balance
+                  Available balance
                 </Type>{" "}
                 /{" "}
                 <Type
@@ -79,7 +79,7 @@ const BalanceSection = connect(state => ({
                 </Type>
               </>
             ) : (
-              <Type>Wallet Balance</Type>
+              <Type>Available balance</Type>
             )}
           </Type>
           <Flex py={6} alignItems={"center"}>

--- a/app/containers/modals/receive.js
+++ b/app/containers/modals/receive.js
@@ -9,7 +9,7 @@ import { selectWalletStacksAddress } from "@stores/selectors/wallet";
 const ReceiveModal = connect(state => ({
   address: selectWalletStacksAddress(state)
 }))(({ address, hide, ...rest }) => (
-  <Modal title="Receive Stacks" hide={hide} maxWidth={"560px"} p={0}>
+  <Modal title="Receive Stacks (STX)" hide={hide} maxWidth={"560px"} p={0}>
     <Flex
       p={4}
       borderBottom={1}
@@ -22,7 +22,7 @@ const ReceiveModal = connect(state => ({
       <QrCode value={address} />
     </Flex>
     <Flex p={4} width={1}>
-      <Field width={1} label="Stacks Address" value={address} disabled copy />
+      <Field width={1} label="Stacks address" value={address} disabled copy />
     </Flex>
   </Modal>
 ));

--- a/app/containers/modals/send.js
+++ b/app/containers/modals/send.js
@@ -69,7 +69,7 @@ const mapStateToProps = state => ({
   error: selectWalletError(state)
 });
 
-const Wrapper = props => <Modal title="Send Stacks" {...props} />;
+const Wrapper = props => <Modal title="Send Stacks (STX)" {...props} />;
 
 class SendComponent extends React.Component {
   state = {

--- a/app/containers/modals/send/initial.js
+++ b/app/containers/modals/send/initial.js
@@ -23,7 +23,7 @@ const InitialScreen = ({
       label="Recipient"
       error={state.errors.recipient}
       onChange={e => handleChange(e, setState, "recipient")}
-      placeholder="Enter a Stacks Address"
+      placeholder="Enter a Stacks address"
       value={state.values.recipient}
       autofocus
     />

--- a/app/containers/modals/send/initial.js
+++ b/app/containers/modals/send/initial.js
@@ -31,7 +31,7 @@ const InitialScreen = ({
     <Field
       name="amount"
       overlay="STX"
-      label="Amount to Send"
+      label="Amount to send"
       onChange={e => handleChange(e, setState, "amount")}
       type="number"
       error={state.errors.amount}

--- a/app/containers/modals/send/top-up.js
+++ b/app/containers/modals/send/top-up.js
@@ -65,7 +65,7 @@ const BTCTopUpView = ({
                 You don't have enough BTC to fund this transaction.
               </Type>
               <Type fontSize={2} lineHeight={1.5}>
-                BTC is used to pay fees for Stacks transactions. Please send at
+                You need BTC to pay fees for Stacks transactions. Please send at
                 least {satoshisToBtc(difference)} BTC to continue.
               </Type>
               <Flex

--- a/app/containers/modals/send/top-up.js
+++ b/app/containers/modals/send/top-up.js
@@ -92,7 +92,7 @@ const BTCTopUpView = ({
       </Flex>
       <Flex flexDirection="column" p={4} pb={0}>
         <StaticField
-          label="BTC Amount Needed"
+          label="BTC amount needed"
           value={`${satoshisToBtc(difference)}`}
         />
         <BtcField />

--- a/app/containers/modals/settings.js
+++ b/app/containers/modals/settings.js
@@ -51,7 +51,7 @@ const TopUpSection = connect(state => ({
       <Card>
         <Flex p={4} borderRight={1} borderColor="blue.mid" flexGrow={1}>
           <Type>
-            You need small amounts of Bitcoin (BTC) to send Stacks (STX). A few satoshis is generally enough. You
+            You need very small amounts of Bitcoin (BTC) to send Stacks (STX). You
             currently have {satoshisToBtc(balance)} BTC available.
           </Type>
         </Flex>
@@ -86,7 +86,7 @@ const DangerZone = connect(
         flexGrow={1}
       >
         <Type>
-          Resetting removes your Stacks Wallet setup. It does not affect your Stacks addresses or the STX balances on them. You need your seed phrase to gain access to them again. <strong>Record and store your seed phrase securely before you reset.</strong> </Type>
+          Resetting removes your Stacks Wallet setup. It does not affect your Stacks addresses or the STX balances on them. You need your seed phrase to gain access to them again. <strong>Make sure you have stored your seed phrase securely.</strong> </Type>
       </Flex>
       <Flex justifyContent="center" alignItems="center" p={4} >
         <State initial={{ clicked: false }}>

--- a/app/containers/modals/settings.js
+++ b/app/containers/modals/settings.js
@@ -46,20 +46,20 @@ const TopUpSection = connect(state => ({
   type !== WALLET_TYPES.WATCH_ONLY ? (
     <Section>
       <Label pb={4} fontSize={2}>
-        Transaction Fees
+        Transaction fees
       </Label>
       <Card>
         <Flex p={4} borderRight={1} borderColor="blue.mid" flexGrow={1}>
           <Type>
-            Bitcoin is used to pay transaction fees for Stacks transactions. You
-            currently have {satoshisToBtc(balance)} BTC.
+            You need small amounts of Bitcoin (BTC) to send Stacks (STX). A few satoshis is generally enough. You
+            currently have {satoshisToBtc(balance)} BTC available.
           </Type>
         </Flex>
         <Flex justifyContent="center" p={4}>
           <OpenModal component={TxFeesModal}>
             {({ bind }) => (
               <Button height={"auto"} py={2} {...bind}>
-                Top Up
+                Add BTC
               </Button>
             )}
           </OpenModal>
@@ -75,7 +75,7 @@ const DangerZone = connect(
 )(({ doResetWallet, hide, ...rest }) => (
   <Section>
     <Label pb={4} fontSize={2}>
-      Danger Zone
+    Reset wallet setup
     </Label>
     <Card>
       <Flex
@@ -85,13 +85,10 @@ const DangerZone = connect(
         borderColor="blue.mid"
         flexGrow={1}
       >
-        <Label>Reset Wallet</Label>
         <Type>
-          This will remove all data and you’ll have to restore it to gain
-          access.
-        </Type>
+          Resetting removes your Stacks Wallet setup. It does not affect your Stacks addresses or the STX balances on them. You need your seed phrase to gain access to them again. <strong>Record and store your seed phrase securely before you reset.</strong> </Type>
       </Flex>
-      <Flex justifyContent="center" alignItems="center" p={4}>
+      <Flex justifyContent="center" alignItems="center" p={4} >
         <State initial={{ clicked: false }}>
           {({ state, setState }) => {
             if (state.clicked) {
@@ -103,6 +100,7 @@ const DangerZone = connect(
                   }}
                   height={"auto"}
                   py={2}
+                  bg="#EF4813"
                 >
                   Are you sure?
                 </Button>
@@ -115,8 +113,9 @@ const DangerZone = connect(
                 }}
                 height={"auto"}
                 py={2}
+                bg="#EF4813"
               >
-                Reset Wallet
+                Reset wallet
               </Button>
             );
           }}

--- a/app/containers/modals/software-warning.js
+++ b/app/containers/modals/software-warning.js
@@ -43,7 +43,7 @@ const Section = ({ ...rest }) => (
 
 const SoftwareWarningModal = ({ hide, proceed, history, ...rest }) => {
   return (
-    <Modal title="Warning" hide={hide} p={0} width="90vw">
+    <Modal title="Caution: A hardware wallet is recommended" fontSize={4} hide={hide} p={0} width="90vw">
       <Flex 
         flexDirection="column" 
         p={4} 
@@ -51,15 +51,6 @@ const SoftwareWarningModal = ({ hide, proceed, history, ...rest }) => {
         textAlign="center"
         justifyContent="center"
         alignItems="center">
-        <Type      
-          pb={2}
-          Type
-          lineHeight={1.5}
-          fontSize={4}
-          pt={4}
-          maxWidth="600px">
-            We highly recommend a hardware wallet
-          </Type>
           <Type      
             pb={2}
             Type
@@ -67,14 +58,11 @@ const SoftwareWarningModal = ({ hide, proceed, history, ...rest }) => {
             fontSize={2}
             pt={4}
             maxWidth="600px">
-            Hardware wallets affordably protect you from token loss and theft 
-            should your computer get hacked or your records lost. <br/><br/>
-            Please read our documentation about hardware wallets to ensure you 
-            understand their benefits and the risks of proceeding without one.
+            Hardware wallets further protect you from token loss and theft should your computer get hacked or your records lost. To ensure you understand their benefits and the risks of proceeding without one, please read our documentation.
           </Type>
           <Buttons maxWidth="420px" mx="auto" flexDirection="column" pt={5} pb={5}>
             <Button onClick={() => proceed(hide)} mb={3} bg="#EF4813">
-              Proceed without hardware
+              Continue without a hardware wallet
             </Button>
             <Button onClick={hide}>
               Back

--- a/app/containers/modals/tx-fees-top-up.js
+++ b/app/containers/modals/tx-fees-top-up.js
@@ -37,8 +37,8 @@ const TxFeesModal = ({ hide }) => (
             py={4}
           >
             <Type pb={4} fontSize={4} lineHeight={1.5}>
-              Bitcoin is only used to pay fees for Stacks transactions. You will
-              not be able to send Bitcoin from this wallet.
+              Bitcoin (BTC) is only used to pay fees for Stacks (STX) transactions. You cannot
+              send BTC from this wallet.
             </Type>
             <Button
               onClick={() =>

--- a/app/screens/dashboard/index.js
+++ b/app/screens/dashboard/index.js
@@ -129,7 +129,7 @@ const Dashboard = ({
         <>
           <Balance />
           <TxList
-            title="Transaction History"
+            title="Transaction history"
             contentHeader={<TableHeader items={tableHeadItems} />}
             action={{
               label: fetching ? (

--- a/app/screens/onboarding/confirm-seed/index.js
+++ b/app/screens/onboarding/confirm-seed/index.js
@@ -119,7 +119,7 @@ class ConfirmSeedScreen extends Component {
           {...rest}
         >
           <Box maxWidth="600px">
-            <Title>Confirm Your Seed Phrase</Title>
+            <Title>Confirm your seed phrase</Title>
           </Box>
           <Type
             pt={5}
@@ -130,7 +130,7 @@ class ConfirmSeedScreen extends Component {
             color="hsl(242, 56%, 75%)"
             maxWidth="600px"
           >
-            Provide all 24 words of your seed phrase by number to confirm you've written them down in order properly.
+            Enter the 24 words of your seed phrase in the order requested below. The numbers represent each word's corresponding position in your seed phrase. 
           </Type>
           <Seed 
             seedPhrase={seed} 

--- a/app/screens/onboarding/initial/index.js
+++ b/app/screens/onboarding/initial/index.js
@@ -67,16 +67,28 @@ class InitialScreen extends Component {
           color="hsl(242, 56%, 75%)"
           maxWidth="300px"
         >
-          Choose one of the following options to setup your Stacks wallet.
+          Choose one of the following options to set up a Stacks wallet.
         </Type>
         <Buttons maxWidth="420px" mx="auto" flexDirection="column" pt={5}>
           <Button outline is={Link} invert to={ROUTES.NEW_OPTIONS}>
-            New Wallet
+            Create new wallet
           </Button>
           <Button outline is={Link} mt={4} invert to={ROUTES.RESTORE_OPTIONS}>
-            Restore Wallet
+            Restore existing wallet
           </Button>
         </Buttons>
+        <Type
+            pt={5}
+            pb={1}
+            Type
+            lineHeight={1.5}
+            fontSize={1}
+            textAlign="right"
+            color="white"
+            maxWidth="600px"
+          >
+          <a href="https://docs.blockstack.org/org/wallet-use.html" target='_blank'>Wallet help</a>
+          </Type>
         <Type 
           position="absolute" 
           bottom="15px" 

--- a/app/screens/onboarding/new-seed/index.js
+++ b/app/screens/onboarding/new-seed/index.js
@@ -65,7 +65,7 @@ class NewSeedScreen extends Component {
             <Title>Secure your seed phrase</Title>
           </Box>
           <Type
-            pt={5}
+            pt={4}
             pb={1}
             Type
             lineHeight={1.5}
@@ -73,22 +73,22 @@ class NewSeedScreen extends Component {
             color="hsl(242, 56%, 75%)"
             maxWidth="600px"
           >
-            A seed phrase is a unique sequence of 24 words provided to you when you create a wallet. You must enter your seed phrase to send Stacks (STX) tokens. 
+            A unique 24-word sequence generated for you when you create a wallet. You enter your seed phrase to open your wallet or to send Stacks (STX) tokens. 
           </Type>
           <Type
-            pt={5}
+            pt={2}
             pb={1}
             Type
             lineHeight={1.5}
-            fontSize={3}
+            fontSize={2}
             textAlign="center"
             color="white"
             maxWidth="600px"
           >
-            Don't lose your seed phrase. If you lose your seed phrase, you lose your STX tokens and can <strong>never</strong> get them back. <a href="https://docs.blockstack.org/org/secureref.html" target='_blank'>Read about wallet security</a>
+            Don't lose your seed phrase. If you lose your seed phrase, you lose your STX tokens and can <em><strong>never</strong></em> get them back. <a href="https://docs.blockstack.org/org/secureref.html" target='_blank'>Read about wallet security</a>
           </Type>
           <Type
-            pt={5}
+            pt={4}
             pb={1}
             Type
             lineHeight={1.5}

--- a/app/screens/onboarding/new-seed/index.js
+++ b/app/screens/onboarding/new-seed/index.js
@@ -58,11 +58,11 @@ class NewSeedScreen extends Component {
           color="white"
           justifyContent="center"
           alignItems="center"
-          textAlign="center"
+          textAlign="left"
           {...rest}
         >
           <Box maxWidth="600px">
-            <Title>Secure Your Seed Phrase</Title>
+            <Title>Secure your seed phrase</Title>
           </Box>
           <Type
             pt={5}
@@ -73,17 +73,35 @@ class NewSeedScreen extends Component {
             color="hsl(242, 56%, 75%)"
             maxWidth="600px"
           >
-            Every wallet is derived from a uniquely generated, 24-word sequence called a "seed phrase". 
-            You must provide this seed phrase every time you want to perform a transaction.
-            <br/><br/>
-            Write down the seed phrase below. Secure the written seed phrase in a safe deposit box or similar.
-            If you lose your seed phrase, you lose all your tokens. <br/>
-            <a href="https://docs.blockstack.org/org/wallet-intro.html" target='_blank'>Read more</a>
+            A seed phrase is a unique sequence of 24 words provided to you when you create a wallet. You must enter your seed phrase to send Stacks (STX) tokens. 
           </Type>
+          <Type
+            pt={5}
+            pb={1}
+            Type
+            lineHeight={1.5}
+            fontSize={3}
+            textAlign="center"
+            color="white"
+            maxWidth="600px"
+          >
+            Don't lose your seed phrase. If you lose your seed phrase, you lose your STX tokens and can <strong>never</strong> get them back. <a href="https://docs.blockstack.org/org/secureref.html" target='_blank'>Read about wallet security</a>
+          </Type>
+          <Type
+            pt={5}
+            pb={1}
+            Type
+            lineHeight={1.5}
+            fontSize={2}
+            color="hsl(242, 56%, 75%)"
+            maxWidth="600px"
+          >
+            This is your seed phrase. <strong>(1)</strong> Write down each position and word, for example, <code>1 - frog</code>. <strong>(2)</strong> Store the written seed phrase in a secure location such as a safe deposit box. 
+            </Type>
           <Seed seedPhrase={seed} isInput={false} small={true}/>
           <Buttons maxWidth="420px" mx="auto" flexDirection="column" pt={4}>
             <Button outline is={Link} invert to={ROUTES.CONFIRM_SEED}>
-              I've written these down in order
+              I've written down my seed phrase
             </Button>
             <OnboardingNavigation
                   onDark

--- a/app/screens/onboarding/new/index.js
+++ b/app/screens/onboarding/new/index.js
@@ -36,7 +36,7 @@ const NewScreen = ({ ...props }) => (
     {...props}
   >
     <Box maxWidth="400px">
-      <Title>Do you have a Hardware Wallet?</Title>
+      <Title>Do you have a hardware wallet?</Title>
     </Box>
     <Type
       pb={2}
@@ -50,14 +50,14 @@ const NewScreen = ({ ...props }) => (
     </Type>
     <Buttons maxWidth="420px" mx="auto" flexDirection="column" pt={5}>
       <Button outline is={Link} invert to={ROUTES.RESTORE_HARDWARE}>
-        Yes
+        Yes, I do
       </Button>
       <OpenModal component={({ visible, hide }) => 
         <WarningModal hide={hide} proceed={(hide) => proceed(hide, props.history)} />
         }>
         {({ bind }) => (
           <Button outline mt={4} invert {...bind}>
-            No
+            No, I don't
           </Button>
         )}
       </OpenModal>

--- a/app/screens/onboarding/restore-seed/index.js
+++ b/app/screens/onboarding/restore-seed/index.js
@@ -186,7 +186,7 @@ class RestoreSeedScreen extends Component {
           {...rest}
         >
           <Box maxWidth="600px">
-            <Title>Enter Your Seed Phrase</Title>
+            <Title>Enter your seed phrase</Title>
           </Box>
           <Type
             pt={5}
@@ -197,7 +197,7 @@ class RestoreSeedScreen extends Component {
             color="hsl(242, 56%, 75%)"
             maxWidth="600px"
           >
-            Provide all 24 words of your seed phrase in order to restore your wallet.
+            Restore your wallet by entering the 24 words of your seed phrase in the correct order.
           </Type>
           {/* <SeedLengthSelector length={this.state.seedLength} handleClick={this.handleSeedLengthClick} /> */}
           <Seed 

--- a/app/screens/onboarding/restore/index.js
+++ b/app/screens/onboarding/restore/index.js
@@ -28,7 +28,7 @@ const RestoreScreen = ({ ...props }) => (
     {...props}
   >
     <Box maxWidth="400px">
-      <Title>Do you have a Hardware Wallet?</Title>
+      <Title>Do you have a hardware wallet?</Title>
     </Box>
     <Type
       pb={2}
@@ -42,10 +42,10 @@ const RestoreScreen = ({ ...props }) => (
     </Type>
     <Buttons maxWidth="420px" mx="auto" flexDirection="column" pt={5}>
       <Button outline is={Link} invert to={ROUTES.RESTORE_HARDWARE}>
-        Yes
+        Yes, I do
       </Button>
       <Button outline is={Link} mt={4} invert to={ROUTES.RESTORE_SEED}>
-        No
+        No, I don't
       </Button>
       <OnboardingNavigation
             onDark

--- a/app/screens/onboarding/watch-only/index.js
+++ b/app/screens/onboarding/watch-only/index.js
@@ -82,7 +82,7 @@ class WatchOnlyScreen extends Component {
       <Page
         alignItems="center"
         justifyContent="center"
-        title="Create a Watch Only Wallet"
+        title="Create a watch-only wallet"
         {...rest}
       >
         <Flex flexDirection={"column"} maxWidth="600px">
@@ -97,7 +97,7 @@ class WatchOnlyScreen extends Component {
               value={address}
               error={this.state.error}
               onChange={this.handleChange}
-              label="Stacks Address"
+              label="Stacks address"
               autoFocus
               placeholder="SM3KJBA4RZ7Z20KD2HBXNSXVPCR1D3CRAV6Q05MKT"
             />

--- a/app/screens/onboarding/watch-only/index.js
+++ b/app/screens/onboarding/watch-only/index.js
@@ -59,7 +59,7 @@ class WatchOnlyScreen extends Component {
   handleSubmit = () => {
     if (this.state.value === "") {
       this.setState({
-        error: "Please enter a Stacks Address"
+        error: "Please enter a Stacks address"
       });
       return null;
     }

--- a/app/store/actions/wallet.js
+++ b/app/store/actions/wallet.js
@@ -90,7 +90,7 @@ const doClearSeed = () => dispatch =>
   });
 
 /**
- * Fetch our data for the Stacks Address
+ * Fetch our data for the Stacks address
  * Address should already be validated before calling this function
  * @param {string} address - the stacks address we want data on
  */


### PR DESCRIPTION
This started with a base of `feature/software-wallet` per @yknl. Implemented changes approved in @markmhx  with some modifications. Includes:

- seed phrase > passphrase
- sentence case on all headings
- using same address balance language as appears in explorer where possible
- some other modifications to language to support 24 word and reinforce passphrase security

Build and run to see all changes of course. Key dialogs:

![image](https://user-images.githubusercontent.com/1347209/57424203-ca6dbd00-71cb-11e9-98f0-03fa9e75ff03.png)

![image](https://user-images.githubusercontent.com/1347209/57424211-cfcb0780-71cb-11e9-84a6-d3fc390f43de.png)

![image](https://user-images.githubusercontent.com/1347209/57424216-d5285200-71cb-11e9-8f83-f00ee98cd2dd.png)

![image](https://user-images.githubusercontent.com/1347209/57424228-dd808d00-71cb-11e9-9f28-e1a2de0e5f36.png)


Signed-off-by: Mary Anthony <mary@blockstack.com>

