### PR TITLE
Clarify cost basis fixes #90

### DIFF
--- a/app/containers/modals/settings.js
+++ b/app/containers/modals/settings.js
@@ -51,8 +51,8 @@ const TopUpSection = connect(state => ({
       <Card>
         <Flex p={4} borderRight={1} borderColor="blue.mid" flexGrow={1}>
           <Type>
-            You need very small amounts of Bitcoin (BTC) to send Stacks (STX). You
-            currently have {satoshisToBtc(balance)} BTC available.
+            You need very small amounts of Bitcoin (BTC) to send Stacks (STX). The transaction cost varies with the BTC market price. The cost is per transaction and not related to the amount of Stacks sent. You
+            currently have <strong>{satoshisToBtc(balance)}</strong> BTC available.
           </Type>
         </Flex>
         <Flex justifyContent="center" p={4}>

--- a/app/containers/modals/tx-fees-top-up.js
+++ b/app/containers/modals/tx-fees-top-up.js
@@ -7,7 +7,7 @@ import { BtcField } from "@containers/fields/btc-address";
 
 const TxFeesModal = ({ hide }) => (
   <Modal
-    title="Add BTC"
+    title="Add BTC for transaction fees"
     hide={hide}
     maxWidth={"560px"}
     p={0}

--- a/app/containers/modals/tx-fees-top-up.js
+++ b/app/containers/modals/tx-fees-top-up.js
@@ -7,7 +7,7 @@ import { BtcField } from "@containers/fields/btc-address";
 
 const TxFeesModal = ({ hide }) => (
   <Modal
-    title="Top Up"
+    title="Add BTC"
     hide={hide}
     maxWidth={"560px"}
     p={0}
@@ -27,7 +27,7 @@ const TxFeesModal = ({ hide }) => (
             alignItems="center"
             justifyContent="center"
             flexDirection="column"
-            textAlign="center"
+            textAlign="left"
             transition={"0.5s all cubic-bezier(.19,1,.22,1)"}
             opacity={state.view === "warning" ? 1 : 0}
             style={{
@@ -37,8 +37,7 @@ const TxFeesModal = ({ hide }) => (
             py={4}
           >
             <Type pb={4} fontSize={4} lineHeight={1.5}>
-              Bitcoin (BTC) is only used to pay fees for Stacks (STX) transactions. You cannot
-              send BTC from this wallet.
+            You cannot send Bitcoin (BTC) from this wallet. BTC is only used to pay a transaction fees for sending Stacks (STX). The BTC is per transaction and not related to the amount of Stacks sent. 
             </Type>
             <Button
               onClick={() =>

--- a/app/store/actions/wallet.js
+++ b/app/store/actions/wallet.js
@@ -391,7 +391,7 @@ const doSignTransaction = (
       doNotifyWarning({
         title: "Not enough BTC",
         message:
-          "Looks like you don't have enough BTC to pay the associated transaction fees for this transaction."
+          "Looks like you don't have enough BTC to pay the fee for this transaction."
       })(dispatch);
       return;
     }


### PR DESCRIPTION
Adds clarifying language to settings.

![image](https://user-images.githubusercontent.com/1347209/58891864-1d8b4080-86a2-11e9-9741-5f11385a278a.png)

Also to the pop-up

![image](https://user-images.githubusercontent.com/1347209/58891895-2aa82f80-86a2-11e9-8a14-7815ac0430f5.png)


Signed-off-by: Mary Anthony <mary@blockstack.com>