### PR TITLE
Add blockchain version compatibility check 

### DIFF
--- a/app/common/constants.js
+++ b/app/common/constants.js
@@ -5,7 +5,7 @@ const BSKPK =
 
 const PATH = `m/44'/5757'/0'/0/0`;
 
-const CORE_NODE_URI = "http://testnet.blockstack.org:16268";
+const CORE_NODE_URI = "https://core.blockstack.org";
 
 const CORE_NODE_URI_TEST_NET = "http://testnet.blockstack.org:16268";
 
@@ -28,6 +28,8 @@ const HAS_WINDOW = typeof window !== "undefined";
 const IS_BROWSER = HAS_WINDOW || typeof self !== "undefined";
 
 const IS_PROD = process.env.NODE_ENV === "production";
+
+const STACKS_BLOCKCHAIN_VERSION = "1.0"
 
 const ROUTES = {
   TERMS: "/",
@@ -56,5 +58,6 @@ export {
   HAS_WINDOW,
   IS_BROWSER,
   IS_PROD,
-  ROUTES
+  ROUTES,
+  STACKS_BLOCKCHAIN_VERSION
 };

--- a/app/common/lib/transactions.js
+++ b/app/common/lib/transactions.js
@@ -111,8 +111,9 @@ const prepareTransaction = async (
       difference: estimate - btcBalance
     };
   }
+  
   // not enough stacks (should be impossible to get here)
-  if (currentAccountBalance.compareTo(tokenAmount) < 0) {
+  if (currentAccountBalance < tokenAmount) {
     return ERRORS.INSUFFICIENT_STX_BALANCE;
   }
 

--- a/app/components/transaction-item/index.js
+++ b/app/components/transaction-item/index.js
@@ -208,7 +208,7 @@ const TxItem = ({ last, item, length, stx, ...rest }) => {
   const {
     operation,
     recipient,
-    blockTime,
+    blockUnixTime,
     pending,
     invalid,
     valueStacks,
@@ -226,8 +226,8 @@ const TxItem = ({ last, item, length, stx, ...rest }) => {
     >
       {({ bind }) => (
         <Item {...bind} last={last} length={length} {...rest}>
-          {blockTime || time || received ? (
-            <Date date={blockTime || time * 1000 || received} />
+          {blockUnixTime || time || received ? (
+            <Date date={blockUnixTime || time * 1000 || received} />
           ) : null}
           <TypeIcon mr={3} item={item} stx={stx} />
           <Details

--- a/app/components/transaction-item/index.js
+++ b/app/components/transaction-item/index.js
@@ -227,7 +227,7 @@ const TxItem = ({ last, item, length, stx, ...rest }) => {
       {({ bind }) => (
         <Item {...bind} last={last} length={length} {...rest}>
           {blockUnixTime || time || received ? (
-            <Date date={blockUnixTime || time * 1000 || received} />
+            <Date date={blockUnixTime*1000 || time * 1000 || received} />
           ) : null}
           <TypeIcon mr={3} item={item} stx={stx} />
           <Details

--- a/app/containers/balance/index.js
+++ b/app/containers/balance/index.js
@@ -15,10 +15,12 @@ import {
   selectWalletBalance,
   selectPendingBalance
 } from "@stores/selectors/wallet";
+import { selectAppUpdateRequired } from "@stores/selectors/app";
 import { microToStacks } from "stacks-utils";
 import { WALLET_TYPES } from "@stores/reducers/wallet";
 import { Notice } from "@components/notice";
 import { formatMicroStxValue } from "@utils/utils";
+import { shell } from "electron";
 
 const funct = ({ visible, hide }) => (
   <ReceiveModal hide={hide} visible={visible} />
@@ -122,8 +124,9 @@ const BalanceSection = connect(state => ({
 });
 
 const Balance = connect(state => ({
-  type: selectWalletType(state)
-}))(({ type, ...rest }) => (
+  type: selectWalletType(state),
+  updateRequired: selectAppUpdateRequired(state)
+}))(({ type, updateRequired, ...rest }) => (
   <Flex
     flexShrink={0}
     width={1}
@@ -132,17 +135,31 @@ const Balance = connect(state => ({
     {...rest}
   >
     <BalanceSection pt={6} pb={5} />
+    {type === WALLET_TYPES.WATCH_ONLY ?       
+      <Notice>
+        This is a watch only wallet, you can view your balance and transaction
+        history only.
+      </Notice>
+      : null }
     {type !== WALLET_TYPES.WATCH_ONLY ? (
       <Buttons pb={5}>
         <SendButton />
         <ReceiveButton />
       </Buttons>
-    ) : (
+    ) : null}
+    {updateRequired ? (
       <Notice>
-        This is a watch only wallet, you can view your balance and transaction
-        history only.
+        Your wallet software needs to be updated in order to send
+        transactions. &nbsp;
+        <Type 
+          cursor="pointer" 
+          fontWeight="bold"
+          onClick={() => {shell.openExternal("https://wallet.blockstack.org/")}}
+        >
+        Download Update
+        </Type>
       </Notice>
-    )}
+    ) : null}
   </Flex>
 ));
 

--- a/app/preload.js
+++ b/app/preload.js
@@ -47,7 +47,8 @@ const moduleWhiteList = [
 	'qrcode.react',
 	'redux',
 	'redux-thunk',
-	'lodash.debounce'
+	'lodash.debounce',
+	'semver'
 ]
 
 if (process.env.NODE_ENV === 'development') {

--- a/app/screens/dashboard/index.js
+++ b/app/screens/dashboard/index.js
@@ -16,7 +16,7 @@ import {
 } from "@stores/selectors/wallet";
 import { ReceiveButton } from "@containers/balance";
 import { ButtonCombo } from "@containers/buttons/onboarding-navigation";
-import { doRefreshData } from "@stores/actions/wallet";
+import { doRefreshData, doCompatibilityCheck } from "@stores/actions/wallet";
 import debounce from "lodash.debounce";
 import { Spinner } from "@components/spinner";
 

--- a/app/screens/onboarding/initial/index.js
+++ b/app/screens/onboarding/initial/index.js
@@ -96,7 +96,7 @@ class InitialScreen extends Component {
           fontSize="12px" 
           onClick={() => this.handleClicks(this.props.history)}
           >
-          v3.0.1
+          v3.0.2
         </Type>
       </Flex>
     )

--- a/app/store/reducers/app.js
+++ b/app/store/reducers/app.js
@@ -6,10 +6,13 @@ export const APP_IDLE = "app/APP_IDLE";
 export const TOGGLE_MODAL = "app/TOGGLE_MODAL";
 export const TOGGLE_MODAL_CLOSE = "app/TOGGLE_MODAL_CLOSE";
 export const TOGGLE_MODAL_KEEP_OPEN = "app/TOGGLE_MODAL_KEEP_OPEN";
+export const APP_UPDATE_REQUIRED = "app/APP_UPDATE_REQUIRED";
+export const APP_UPDATE_NOT_REQUIRED = "app/APP_UPDATE_NOT_REQUIRED";
 
 const initialState = {
   terms: false,
   keepModalOpen: false,
+  appUpdateRequired: false,
   appTime: Date.now()
 };
 
@@ -25,6 +28,12 @@ export default function reducer(state = initialState, { type, payload }) {
         break;
       case TOGGLE_MODAL_KEEP_OPEN:
         draft.keepModalOpen = true;
+        break;
+      case APP_UPDATE_REQUIRED:
+        draft.updateRequired = true;
+        break;
+      case APP_UPDATE_NOT_REQUIRED:
+        draft.updateRequired = false;
         break;
       case ACCEPT_TERMS:
         draft.terms = true;

--- a/app/store/reducers/notifications.js
+++ b/app/store/reducers/notifications.js
@@ -30,9 +30,7 @@ const doRemoveNotification = item => dispatch =>
   });
 
 const doCancelNotification = (cancelMap, item, secondPass = false) => {
-  console.log("doCancelNotification");
   if (cancelMap.has(item)) {
-    console.log("doCancelNotification has item");
     const fn = cancelMap.get(item);
     fn();
     if (secondPass) fn();

--- a/app/store/selectors/app.js
+++ b/app/store/selectors/app.js
@@ -1,5 +1,6 @@
 const selectAppTime = ({ app }) => app.appTime;
 const selectAcceptedTerms = ({ app }) => app.terms;
 const selectToggleModal = ({ app }) => app.keepModalOpen;
+const selectAppUpdateRequired = ({ app }) => app.updateRequired
 
-export { selectAppTime, selectAcceptedTerms, selectToggleModal };
+export { selectAppTime, selectAcceptedTerms, selectToggleModal, selectAppUpdateRequired };

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,6 +188,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2971,6 +2976,12 @@
           "version": "1.3.133",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz",
           "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -6563,6 +6574,14 @@
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "babel-preset-fbjs": {
@@ -8919,6 +8938,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "cross-unzip": {
@@ -10091,6 +10118,12 @@
           "requires": {
             "pseudomap": "^1.0.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -10285,6 +10318,14 @@
             "rc": "^1.1.2",
             "semver": "^5.3.0",
             "sumchecker": "^2.0.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "fs-extra": {
@@ -10327,6 +10368,14 @@
         "cross-unzip": "0.0.2",
         "rimraf": "^2.5.2",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "electron-download": {
@@ -10352,6 +10401,11 @@
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -10881,6 +10935,12 @@
             "esprima": "^4.0.0"
           }
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -11005,6 +11065,14 @@
         "node-libs-browser": "^1.0.0 || ^2.0.0",
         "resolve": "^1.4.0",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "eslint-module-utils": {
@@ -11864,6 +11932,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -12162,6 +12236,12 @@
           "requires": {
             "lcid": "^1.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         },
         "which-module": {
           "version": "1.0.0",
@@ -14828,6 +14908,12 @@
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
           "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -16419,6 +16505,12 @@
           "version": "16.8.6",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
           "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "to-fast-properties": {
@@ -18331,6 +18423,12 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
           "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -18384,6 +18482,14 @@
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "node-fetch": {
@@ -18538,6 +18644,14 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "node-object-hash": {
@@ -18553,6 +18667,14 @@
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "node-sass": {
@@ -18763,6 +18885,13 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "normalize-path": {
@@ -19410,6 +19539,13 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "pako": {
@@ -20496,6 +20632,13 @@
           "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
           "requires": {
             "semver": "^5.4.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
           }
         }
       }
@@ -22231,9 +22374,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
+      "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -22247,6 +22390,13 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
         "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "send": {
@@ -24206,6 +24356,14 @@
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "parse-json": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "redux-thunk": "2.2.0",
     "reselect": "4.0.0",
     "rwlock": "5.0.0",
+    "semver": "7.1.1",
     "setimmediate": "1.0.5",
     "shortid": "2.2.14",
     "source-map-support": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stacks-wallet-1",
   "description": "Stacks Wallet",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Blockstack PBC",
     "url": "https://www.blockstack.org"


### PR DESCRIPTION
This PR adds a check for the Stacks blockchain version the connected core node is running. It will disable the sending of transactions when the core node is running a newer and incompatible version of the Stacks blockchain.

Also fixes a problem where no error message is displayed when there isn't enough BTC in the fuel address.

Warning message to update the Stacks wallet.
![image](https://user-images.githubusercontent.com/29081231/73205502-17edd980-410f-11ea-8299-ed34a48725fc.png)
