### PR TITLE
Feat: small library for interacting with pox.clar

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@blockstack/keychain": "0.13.0-beta.2",
     "@blockstack/stacks-transactions": "0.7.0",
-    "@ledgerhq/hw-transport-node-hid": "5.23.2"
+    "@ledgerhq/hw-transport-node-hid": "5.23.2",
+    "bitcoinjs-lib": "^5.2.0"
   }
 }

--- a/app/utils/stacking/pox.spec.ts
+++ b/app/utils/stacking/pox.spec.ts
@@ -1,0 +1,92 @@
+import {
+  makeRandomPrivKey,
+  getAddressFromPrivateKey,
+  TransactionVersion,
+} from '@blockstack/stacks-transactions';
+import { POX } from './pox';
+import { Api } from '../../api/api';
+import BN from 'bn.js';
+import * as bitcoin from 'bitcoinjs-lib';
+
+const client = new POX();
+const api = new Api('http://localhost:3999');
+
+const btcAddress = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem';
+
+const waitForTxConfirm = (txid: string) => {
+  return new Promise((resolve, reject) => {
+    const interval = setInterval(() => {
+      const getTX = async (interval: number) => {
+        try {
+          const txResponse = await api.getTxDetails(txid);
+          if (txResponse.data.tx_status === 'success') {
+            clearInterval(interval);
+            return resolve(true);
+          } else if (txResponse.data.tx_status === 'abort_by_response') {
+            clearInterval(interval);
+            return reject(txResponse.data.tx_result);
+          }
+        } catch (error) {
+          // nothing
+        }
+      };
+      void getTX(interval);
+    }, 500);
+  });
+};
+
+test('making a lock-stx transaction', async () => {
+  const keyPair = bitcoin.ECPair.makeRandom();
+  const { address: poxAddress } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey });
+  if (!poxAddress) {
+    throw new Error('No btc address');
+  }
+  const key = makeRandomPrivKey();
+  const address = getAddressFromPrivateKey(key.data, TransactionVersion.Testnet);
+  const faucetResponse = await api.getFaucetStx(address);
+  await waitForTxConfirm(faucetResponse.data.txId);
+  const lockTxid = await client.lockSTX({
+    amountSTX: 50500000010000 + 500,
+    cycles: 1,
+    poxAddress,
+    key: key.data.toString('hex'),
+  });
+  await waitForTxConfirm(`0x${lockTxid}`);
+  const stackerInfo = await client.getStackerInfo(address);
+  console.log('Stacker Info:');
+  console.log('Amount Locked:', stackerInfo.amountSTX.toString(10));
+  console.log('Lock Period:', stackerInfo.lockPeriod.toString(10));
+  console.log('Address Version:', stackerInfo.poxAddr.version.toString('hex'));
+  console.log('Address Hashbytes:', stackerInfo.poxAddr.hashbytes.toString('hex'));
+  console.log('Bitcoin Address', stackerInfo.btcAddress);
+  const btcReconstruced = client.getBTCAddress(
+    stackerInfo.poxAddr.version,
+    stackerInfo.poxAddr.hashbytes
+  );
+  expect(btcReconstruced).toEqual(poxAddress);
+  expect(stackerInfo.amountSTX.eq(new BN(50500000010000 + 500, 10))).toBeTruthy();
+  expect(stackerInfo.lockPeriod.eq(new BN(1, 10))).toBeTruthy();
+  expect(stackerInfo.poxAddr.version).toEqual(Buffer.from('00', 'hex'));
+  expect(stackerInfo.btcAddress).toEqual(poxAddress);
+}, 55_000);
+
+test('can turn btc address into version, checksum', () => {
+  const { version, hash } = client.convertBTCAddress(btcAddress);
+  expect(version).toEqual(0);
+  expect(hash.toString('hex')).toEqual('47376c6f537d62177a2c41c4ca9b45829ab99083');
+  const reconstructed = client.getBTCAddress(new BN(version).toBuffer(), hash);
+  expect(reconstructed).toEqual(btcAddress);
+});
+
+test('works with p2sh addresses', () => {
+  const pubkeys = [
+    '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
+    '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9',
+    '03c6103b3b83e4a24a0e33a4df246ef11772f9992663db0c35759a5e2ebf68d8e9',
+  ].map(hex => Buffer.from(hex, 'hex'));
+  const { address: poxAddress } = bitcoin.payments.p2sh({
+    redeem: bitcoin.payments.p2ms({ m: 2, pubkeys }),
+  });
+  const converted = client.convertBTCAddress(poxAddress as string);
+  expect(converted.version).toEqual(5);
+});

--- a/app/utils/stacking/pox.ts
+++ b/app/utils/stacking/pox.ts
@@ -1,0 +1,149 @@
+import axios from 'axios';
+import {
+  makeContractCall,
+  bufferCV,
+  uintCV,
+  tupleCV,
+  StacksTestnet,
+  broadcastTransaction,
+  standardPrincipalCV,
+  serializeCV,
+  deserializeCV,
+  TupleCV,
+  ContractCallOptions,
+} from '@blockstack/stacks-transactions';
+import BN from 'bn.js';
+import { address } from 'bitcoinjs-lib';
+
+interface POXInfo {
+  contract_id: string;
+  first_burnchain_block_height: number;
+  min_amount_ustx: number;
+  registration_window_length: 250;
+  rejection_fraction: number;
+  reward_cycle_id: number;
+  reward_cycle_length: number;
+}
+
+interface StackerInfo {
+  amountSTX: BN;
+  firstRewardCycle: BN;
+  lockPeriod: BN;
+  poxAddr: {
+    version: Buffer;
+    hashbytes: Buffer;
+  };
+  btcAddress: string;
+}
+
+export class POX {
+  nodeURL = 'http://localhost:3999';
+
+  async getPOXInfo(): Promise<POXInfo> {
+    const url = `${this.nodeURL}/v2/pox`;
+    const res = await axios.get<POXInfo>(url);
+    return res.data;
+  }
+
+  async lockSTX({
+    amountSTX,
+    poxAddress,
+    cycles,
+    key,
+  }: {
+    key: string;
+    cycles: number;
+    poxAddress: string;
+    amountSTX: number;
+  }) {
+    const info = await this.getPOXInfo();
+    const contract = info.contract_id;
+    const { version, hash } = this.convertBTCAddress(poxAddress);
+    const versionBuffer = bufferCV(new BN(version, 10).toBuffer());
+    const hashbytes = bufferCV(hash);
+    const address = tupleCV({
+      hashbytes,
+      version: versionBuffer,
+    });
+    const [contractAddress, contractName]: string[] = contract.split('.');
+    const network = new StacksTestnet();
+    network.coreApiUrl = 'http://localhost:3999';
+    const txOptions: ContractCallOptions = {
+      contractAddress,
+      contractName,
+      functionName: 'stack-stx',
+      functionArgs: [uintCV(amountSTX), address, uintCV(cycles)],
+      senderKey: key,
+      validateWithAbi: true,
+      network,
+      fee: new BN(5000, 10),
+    };
+    const tx = await makeContractCall(txOptions);
+    const res = await broadcastTransaction(tx, network);
+    if (typeof res === 'string') {
+      return res;
+    }
+    throw new Error(`${res.error} - ${res.reason}`);
+  }
+
+  async getStackerInfo(address: string): Promise<StackerInfo> {
+    const info = await this.getPOXInfo();
+    const args = [`0x${serializeCV(standardPrincipalCV(address)).toString('hex')}`];
+    const res = await this.callReadOnly({
+      contract: info.contract_id,
+      args,
+      functionName: 'get-stacker-info',
+    });
+    const cv = deserializeCV(Buffer.from(res.slice(2), 'hex')) as TupleCV;
+    // Not sure why these types are off
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const data = cv.value.data;
+    const version = data['pox-addr'].data.version.buffer;
+    const hashbytes = data['pox-addr'].data.hashbytes.buffer;
+    return {
+      lockPeriod: data['lock-period'].value,
+      amountSTX: data['amount-ustx'].value,
+      firstRewardCycle: data['first-reward-cycle'].value,
+      poxAddr: {
+        version,
+        hashbytes,
+      },
+      btcAddress: this.getBTCAddress(version, hashbytes),
+    };
+  }
+
+  async callReadOnly({
+    contract,
+    functionName,
+    args,
+  }: {
+    contract: string;
+    functionName: string;
+    args: string[];
+  }) {
+    const [contractAddress, contractName] = contract.split('.');
+    const url = `${this.nodeURL}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
+    const body = {
+      sender: 'ST384HBMC97973427QMM58NY2R9TTTN4M599XM5TD',
+      arguments: args,
+    };
+    // Note: must include this custom header - the default Axios one for JSON
+    // is not accepted by the core node.
+    const response = await axios.post(url, body, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.data.result as string;
+  }
+
+  convertBTCAddress(btcAddress: string) {
+    return address.fromBase58Check(btcAddress);
+  }
+
+  getBTCAddress(version: Buffer, checksum: Buffer) {
+    const btcAddress = address.toBase58Check(checksum, new BN(version).toNumber());
+    return btcAddress;
+  }
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -318,6 +318,11 @@ bip174@^1.0.1:
   resolved "https://registry.yarnpkg.com/bip174/-/bip174-1.0.1.tgz#858a587f9529e22ee9b0572fd884e5783696824d"
   integrity sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ==
 
+bip174@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.0.1.tgz#39cf8ca99e50ce538fb762589832f4481d07c254"
+  integrity sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==
+
 bip32@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.5.tgz#e3808a9e97a880dbafd0f5f09ca4a1e14ee275d2"
@@ -360,6 +365,27 @@ bitcoinjs-lib@^5.1.6:
   dependencies:
     bech32 "^1.1.2"
     bip174 "^1.0.1"
+    bip32 "^2.0.4"
+    bip66 "^1.1.0"
+    bitcoin-ops "^1.4.0"
+    bs58check "^2.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.3"
+    merkle-lib "^2.0.10"
+    pushdata-bitcoin "^1.0.1"
+    randombytes "^2.0.1"
+    tiny-secp256k1 "^1.1.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.0.4"
+    wif "^2.0.1"
+
+bitcoinjs-lib@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz#caf8b5efb04274ded1b67e0706960b93afb9d332"
+  integrity sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==
+  dependencies:
+    bech32 "^1.1.2"
+    bip174 "^2.0.1"
     bip32 "^2.0.4"
     bip66 "^1.1.0"
     bitcoin-ops "^1.4.0"


### PR DESCRIPTION
> [Download the latest builds](https://github.com/blockstack/stacks-wallet/actions/runs/302227080)<!-- Sticky Header Marker -->

[I think I need to rebase, but onto which branch? `release/stacking`? @kyranjamie feel free to massage or cherry pick my one commit from this PR, put it into your own branch, etc.]

I've added a small utility for interacting with `pox.clar`, the core contract for stacking. You can:

- Lock some STX
- Query the state for a stacker

I've only tested this against a local core node and sidecar. For the sidecar, I'm using https://github.com/blockstack/stacks-wallet/pull/257. For the core node, I'm using `feat/pox-devx`, but with some tweaks:

This in the `Stacks.toml` file:

```toml
[[mstx_balance]]
address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
amount = 1000000000000000000

[[mstx_balance]]
address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
amount = 10000000000000000

[[events_observer]]
endpoint = "127.0.0.1:3700"
events_keys = ["*"]
```

To let the default sidecar faucet have plenty of STX to send. I'm running this with ` stacks-node start --config=./testnet/stacks-node/Stacks.toml`.

Once you have the core node and sidecar running (and pointed to each other), you can run the test `pox.spec.ts`. The test will generate a random key, send STX from the faucet, lock the STX, and then query the contract to ensure that the STX are properly locked.

Only the happiest path is tested here. Lots of improvements to be made. Things like:

- Properly sending a BTC address. Right now it's just using a random address for locking. We need logic to take a BTC address string and properly format it for Clarity.
- Error handling - ideally, we should have proper exceptions for each error that occurred. For example, it took me some time to realize that each stacker needs a unique BTC address, but if you decode the errors from Clarity, that's relatively straightforward.
- More tests for different code paths, of course.
- Querying info like how long the reward cycle is, when the next one starts, minimum amount for stacking, etc
- (Once implemented) use new APIs from the Sidecar to pull down the actual BTC transactions used in PoX consensus

We will likely want to turn this into a proper library at some point. That'll require a few features that aren't in the wallet. For example, you can explicitly say "I don't want to Stack", but that's not implemented in this library yet.

There is also work on the sidecar needed to detect new PoX events, the `pox.clar` contract, etc. Consider this a start.

@kyranjamie , please feel free to refactor this code to your liking.