### PR TITLE
fix: presenting available balance when stacking, closes #287

### DIFF
--- a/app/components/home/balance-card.tsx
+++ b/app/components/home/balance-card.tsx
@@ -5,7 +5,7 @@ import { features } from '@constants/index';
 import { toHumanReadableStx } from '@utils/unit-convert';
 import { safeAwait } from '@utils/safe-await';
 import { delay } from '@utils/delay';
-import BN from 'bn.js';
+import { BigNumber } from 'bignumber.js';
 
 interface BalanceCardProps {
   balance: string | null;
@@ -26,9 +26,7 @@ export const BalanceCard: FC<BalanceCardProps> = props => {
     setRequestingTestnetStx(false);
   };
 
-  const balanceBN = new BN(balance || 0, 10);
-  const lockedBN = new BN(lockedStx || 0, 10);
-  const available = balanceBN.sub(lockedBN);
+  const availableBalance = new BigNumber(balance || 0).minus(lockedStx || 0);
 
   return (
     <Box>
@@ -39,12 +37,12 @@ export const BalanceCard: FC<BalanceCardProps> = props => {
         {balance === null ? '–' : toHumanReadableStx(balance)}
       </Text>
 
-      {features.stacking && lockedBN.toNumber() !== 0 && (
+      {features.stacking && lockedStx && (
         <Flex alignItems="center" mt="tight" color="ink.600" fontSize={['14px', '16px']}>
           <EncryptionIcon size="16px" color="#409EF3" display={['none', 'block']} mr="tight" />
           <Text>{toHumanReadableStx(lockedStx || '0')} locked</Text>
           <Text children="·" mx="base-tight" />
-          <Text>{toHumanReadableStx(available)} available</Text>
+          <Text>{toHumanReadableStx(availableBalance.toString())} available</Text>
         </Flex>
       )}
 

--- a/app/pages/home/home.tsx
+++ b/app/pages/home/home.tsx
@@ -11,7 +11,7 @@ import { RootState } from '@store/index';
 import { openInExplorer } from '@utils/external-links';
 import { selectAddress } from '@store/keys';
 import { selectActiveNodeApi } from '@store/stacks-node';
-import { selectAddressBalance } from '@store/address';
+import { selectAddressBalance, selectAvailableBalance } from '@store/address';
 import {
   selectTransactionList,
   selectTransactionsLoading,
@@ -41,6 +41,7 @@ export const Home: FC = () => {
   const {
     address,
     balance,
+    spendableBalance,
     txs,
     pendingTxs,
     loadingTxs,
@@ -155,7 +156,7 @@ export const Home: FC = () => {
   return (
     <>
       {receiveModalOpen && <ReceiveStxModal address={address} />}
-      {txModalOpen && <TransactionModal balance={balance || '0'} address={address} />}
+      {txModalOpen && <TransactionModal balance={spendableBalance || '0'} address={address} />}
 
       <HomeLayout
         transactionList={transactionList}

--- a/app/store/address/address.reducer.ts
+++ b/app/store/address/address.reducer.ts
@@ -1,4 +1,6 @@
 import { createReducer, createSelector } from '@reduxjs/toolkit';
+import { selectStackerInfo } from '@store/stacking';
+import BigNumber from 'bignumber.js';
 
 import { RootState } from '..';
 import { fetchAddressDone, updateAddressBalance } from './address.actions';
@@ -20,3 +22,13 @@ export const addressReducer = createReducer(initialState, builder =>
 export const selectAddressState = (state: RootState) => state.address;
 
 export const selectAddressBalance = createSelector(selectAddressState, state => state.balance);
+
+export const selectAvailableBalance = createSelector(
+  selectAddressState,
+  selectStackerInfo,
+  (address, stackerInfo) => {
+    if (address.balance === null) return null;
+    if (stackerInfo === null) return address.balance;
+    return new BigNumber(address.balance).minus(stackerInfo.amountMicroStx).toString();
+  }
+);


### PR DESCRIPTION
> [Download the latest builds](https://github.com/blockstack/stacks-wallet/actions/runs/329056707)<!-- Sticky Header Marker -->

This PR introduces as new selector what subtracts the stacked amount from the available balance.