### PR TITLE
fix: invalid tx showing up as valid

### DIFF
--- a/app/containers/balance/index.js
+++ b/app/containers/balance/index.js
@@ -15,7 +15,7 @@ import {
   selectWalletBalance,
   selectPendingBalance
 } from "@stores/selectors/wallet";
-import { microToStacks } from "stacks-utils";
+import { microToStacks } from "@blockstack/stacks-utils";
 import { WALLET_TYPES } from "@stores/reducers/wallet";
 import { Notice } from "@components/notice";
 import { formatMicroStxValue } from "@utils/utils";

--- a/app/containers/modals/withdraw/initial.js
+++ b/app/containers/modals/withdraw/initial.js
@@ -15,7 +15,7 @@ import {
   ErrorMessage
 } from "@containers/modals/withdraw/common";
 import { SCREENS } from "@containers/modals/withdraw-btc";
-import { btcAddressToStacksAddress } from "stacks-utils";
+import { btcAddressToStacksAddress } from "@blockstack/stacks-utils";
 
 const mapPropsToState = state => ({
   sender: selectWalletBitcoinAddress(state),

--- a/app/preload.js
+++ b/app/preload.js
@@ -14,7 +14,7 @@ const moduleWhiteList = [
 	'blockstack-ui',
 	'react-router',
 	'react-router-dom',
-	'stacks-utils',
+	'@blockstack/stacks-utils',
 	'reakit',
 	'styled-system',
 	'react-powerplug',

--- a/app/screens/onboarding/initial/index.js
+++ b/app/screens/onboarding/initial/index.js
@@ -96,7 +96,7 @@ class InitialScreen extends Component {
           fontSize="12px" 
           onClick={() => this.handleClicks(this.props.history)}
           >
-          v3.1.0
+          v3.1.1
         </Type>
       </Flex>
     )

--- a/app/store/actions/wallet.js
+++ b/app/store/actions/wallet.js
@@ -47,7 +47,7 @@ import {
   TOGGLE_MODAL_CLOSE
 } from "@stores/reducers/app";
 import { ROUTES } from "@common/constants";
-import { fetchStacksAddressData } from "stacks-utils";
+import { fetchStacksAddressData } from "@blockstack/stacks-utils";
 import { mnemonicToStxAddress, mnemonicToPrivateKey } from "@utils/utils";
 import crypto from "crypto";
 import bip39 from "bip39";

--- a/app/store/selectors/wallet.js
+++ b/app/store/selectors/wallet.js
@@ -1,4 +1,4 @@
-import { microToStacks, stacksToMicro } from "stacks-utils";
+import { microToStacks, stacksToMicro } from "@blockstack/stacks-utils";
 import BigNumber from "bignumber.js"
 
 const selectWalletHistory = state =>

--- a/app/utils/stacks.js
+++ b/app/utils/stacks.js
@@ -1,3 +1,3 @@
-import { decodeRawTx } from "stacks-utils";
+import { decodeRawTx } from "@blockstack/stacks-utils";
 
 export { decodeRawTx };

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -5,7 +5,7 @@ import bip32 from 'bip32'
 import bip39 from 'bip39'
 import { b58ToC32, c32address, versions } from 'c32check'
 import { ECPair } from "bitcoinjs-lib"
-import { microToStacks, stacksToMicro } from "stacks-utils";
+import { microToStacks, stacksToMicro } from "@blockstack/stacks-utils";
 import BigNumber from "bignumber.js"
 import { PATH } from "@common/constants";
 

--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -1,4 +1,4 @@
-import { validateStacksAddress } from "stacks-utils";
+import { validateStacksAddress } from "@blockstack/stacks-utils";
 
 
 export { validateStacksAddress };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stacks-wallet-1",
   "description": "Stacks Wallet",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Blockstack PBC",
     "url": "https://www.blockstack.org"
@@ -104,7 +104,7 @@
     "setimmediate": "1.0.5",
     "shortid": "2.2.14",
     "source-map-support": "0.5.6",
-    "stacks-utils": "0.1.4",
+    "@blockstack/stacks-utils": "0.1.6",
     "styled-components": "4.0.3",
     "styled-icons": "3.6.0",
     "styled-system": "3.1.11",


### PR DESCRIPTION
This PR fixes a bug where invalid STX transactions (valid BTC transaction but rejected by Stacks core node) shows up as a valid STX transaction in the wallet transaction history. This only occurs when the account has no prior transaction history. Fixed by updating to `@blockstack/stacks-utils@0.1.6` https://github.com/blockstack/stacks-utils/pull/17

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Invalid transactions should not show up as valid in history.

