### PR TITLE
refactor: fee estimation logic

### DIFF
--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -37,6 +37,10 @@ export class Api {
     );
   }
 
+  async getFeeRate() {
+    return axios.get<string>(urljoin(this.baseUrl, `/v2/fees/transfer`));
+  }
+
   async getPoxInfo() {
     return axios.get<CoreNodePoxResponse>(urljoin(this.baseUrl, `/v2/pox`));
   }

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -16,6 +16,8 @@ export const MAX_STACKING_CYCLES = 12;
 
 export const MIN_STACKING_CYCLES = 1;
 
+export const STX_TRANSFER_TX_SIZE_BYTES = 180;
+
 export const SUPPORTED_BTC_ADDRESS_FORMATS = ['p2pkh', 'p2sh'] as const;
 
 export const features = {

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -80,7 +80,6 @@ const createWindow = async () => {
     titleBarStyle: process.platform === 'darwin' ? 'hidden' : 'default',
     icon: path.join(__dirname, '../resources/icon-no-padding-512x512.png'),
     webPreferences:
-      // SECURITY: Remove node env
       process.env.NODE_ENV === 'development' || process.env.E2E_BUILD === 'true'
         ? {
             nodeIntegration: true,


### PR DESCRIPTION
> [Download the latest builds](https://github.com/blockstack/stacks-wallet/actions/runs/337617551)<!-- Sticky Header Marker -->

This PR changes the fee estimation logic used in the UI to:

1) Display estimated transaction fee information
2) Calculate the maximum spend by subtracting fee from balance

Previous implementation created a fake transaction with hardcoded values (the user may not have entered an address when choosing to send their entire balance), and used the fee value estimated internally. This was not ideal as an auditor of the code may rightly question "Who the hells address is that?"

This change uses a hard coded stx transaction size value, as a STX transaction is always 180bytes, and uses this as the basis for the fee estimation.

Hoping for reviews from one of @reedrosenbluth @yknl @aulneau @hstove @zone117x 