### PR TITLE
feat: revert to using normal faucet

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,10 +1,6 @@
 name: Audit
 
-on:
-  push:
-    branches: ['release/stacking']
-  pull_request:
-    branches: ['release/stacking']
+on: [push]
 
 jobs:
   audit:

--- a/.github/workflows/build-release-prod.yml
+++ b/.github/workflows/build-release-prod.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn
 
       - name: Build releases
-        run: ./node_modules/.bin/cross-env STX_TEST yarn package-${{ matrix.NPM_COMMAND }}
+        run: ./node_modules/.bin/cross-env yarn package-${{ matrix.NPM_COMMAND }}
         env:
           SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release-prod.yml
+++ b/.github/workflows/build-release-prod.yml
@@ -1,0 +1,77 @@
+name: Build/release production
+
+on: [push]
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            NPM_COMMAND: mac
+
+          - os: ubuntu-latest
+            NPM_COMMAND: linux
+
+          - os: windows-latest
+            NPM_COMMAND: win
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Variables
+        id: vars
+        run: |
+          echo "::set-output name=version::$(cat package.json | jq -r .version)"
+          echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/})"
+          echo "::set-output name=pull_request_id::$(echo $GITHUB_REF)"
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Install packages
+        run: yarn
+
+      - name: Build releases
+        run: ./node_modules/.bin/cross-env STX_TEST yarn package-${{ matrix.NPM_COMMAND }}
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ steps.vars.outputs.pull_request_id }}
+          BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
+
+      - uses: actions/upload-artifact@v2
+        name: Upload Windows build
+        if: matrix.os == 'windows-latest'
+        with:
+          name: stacks-wallet-prod-${{ steps.vars.outputs.version }}-windows
+          path: |
+            release/**/*.exe
+            release/**/*.msi
+
+      - uses: actions/upload-artifact@v2
+        name: Upload MacOS build
+        if: matrix.os == 'macos-latest'
+        with:
+          name: stacks-wallet-prod-${{ steps.vars.outputs.version }}-macos
+          path: release/**/*.dmg
+
+      - uses: actions/upload-artifact@v2
+        name: Upload Linux build
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: stacks-wallet-prod-${{ steps.vars.outputs.version }}-linux
+          path: |
+            release/**/*.deb
+            release/**/*.rpm

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,51 +20,66 @@ jobs:
             NPM_COMMAND: win
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check out Git repository
         uses: actions/checkout@v1
 
-      - name: Get git commit
-        id: git-commit
-        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      - uses: FranzDiebold/github-env-vars-action@v1.2.1
+      - name: Print environment variables
+        run: |
+          echo "GITHUB_REPOSITORY_SLUG=$GITHUB_REPOSITORY_SLUG"
+          echo "GITHUB_REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER"
+          echo "GITHUB_REPOSITORY_OWNER_SLUG=$GITHUB_REPOSITORY_OWNER_SLUG"
+          echo "GITHUB_REPOSITORY_NAME=$GITHUB_REPOSITORY_NAME"
+          echo "GITHUB_REPOSITORY_NAME_SLUG=$GITHUB_REPOSITORY_NAME_SLUG"
+          echo "GITHUB_REF_SLUG=$GITHUB_REF_SLUG"
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+          echo "GITHUB_REF_NAME_SLUG=$GITHUB_REF_NAME_SLUG"
+          echo "GITHUB_SHA_SHORT=$GITHUB_SHA_SHORT"
+          echo "GITHUB_SHA=$GITHUB_SHA"
 
-      - name: Get build date
-        id: build-date
-        run: echo "::set-output name=date::$(date)"
+      - name: Variables
+        id: vars
+        run: |
+          echo "::set-output name=version::$(cat package.json | jq -r .version)"
+          echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/})"
+          echo "::set-output name=pull_request_id::$(echo $GITHUB_REF)"
+
+      # - run: echo "${{github.event.number}} ${{ steps.vars.outputs.branch_name }} ${{ github.event.pull_request.head.sha }} ${{ steps.vars.outputs.sha2 }}"
+
+      # - run: echo "${GITHUB_CONTEXT}"
+      #   env:
+      #     GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      # - run: echo "${GITHUB_CONTEXT}" | jq
+      #   env:
+      #     GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
           node-version: 10
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Install packages
         run: yarn
-
-      - run: echo ${{ matrix.NPM_COMMAND }}
 
       - name: Build releases
         run: ./node_modules/.bin/cross-env DEBUG_PROD=true yarn package-${{ matrix.NPM_COMMAND }}
         env:
+          SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ steps.git-commit.outputs.sha }}
-          BUILD_DATE: ${{ steps.build-date.outputs.date }}
+          PULL_REQUEST: ${{ steps.vars.outputs.pull_request_id }}
+          BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
 
       - uses: actions/upload-artifact@v2
         name: Upload Windows build
         if: matrix.os == 'windows-latest'
         with:
-          name: stacks-wallet-${{ steps.git-commit.outputs.sha }}-windows
+          name: stacks-wallet-${{ steps.vars.outputs.version }}-windows
           path: |
             release/**/*.exe
             release/**/*.msi
@@ -73,19 +88,21 @@ jobs:
         name: Upload MacOS build
         if: matrix.os == 'macos-latest'
         with:
-          name: stacks-wallet-${{ steps.git-commit.outputs.sha }}-macos
+          name: stacks-wallet-${{ steps.vars.outputs.version }}-macos
           path: release/**/*.dmg
 
       - uses: actions/upload-artifact@v2
         name: Upload Linux build
         if: matrix.os == 'ubuntu-latest'
         with:
-          name: stacks-wallet-${{ steps.git-commit.outputs.sha }}-linux
+          name: stacks-wallet-${{ steps.vars.outputs.version }}-linux
           path: |
             release/**/*.deb
             release/**/*.rpm
 
       - uses: lucasmotta/pull-request-sticky-header@1.0.0
+        # Only update it once per build
+        if: matrix.os == 'macos-latest'
         with:
-          header: '> [Download the latest builds](https://github.com/blockstack/stacks-wallet/actions/runs/${{ github.run_id }})'
+          header: '> [Download the latest builds [${{ steps.vars.outputs.version }}]](https://github.com/blockstack/stacks-wallet/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,6 +20,13 @@ jobs:
             NPM_COMMAND: win
 
     steps:
+      - uses: lucasmotta/pull-request-sticky-header@1.0.0
+        # Only update it once per build
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          header: '> _Currently building new release, please wait for the latest_&nbsp; <img src="https://user-images.githubusercontent.com/1618764/97873036-51dfb200-1d17-11eb-89f5-0a922dc3ac92.gif" width="12" />'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:
@@ -102,7 +109,7 @@ jobs:
 
       - uses: lucasmotta/pull-request-sticky-header@1.0.0
         # Only update it once per build
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-latest'
         with:
           header: '> [Download the latest builds [${{ steps.vars.outputs.version }}]](https://github.com/blockstack/stacks-wallet/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches: ['release/stacking']
-  pull_request:
-    branches: ['release/stacking']
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,5 +1,7 @@
 name: Commitlint
-on: [pull_request]
+
+on: [push]
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/exact-versions.yml
+++ b/.github/workflows/exact-versions.yml
@@ -1,9 +1,7 @@
 name: Exact versions
-on:
-  push:
-    branches: [release/stacking]
-  pull_request:
-    branches: [release/stacking]
+
+on: [push]
+
 jobs:
   check-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,6 @@
 name: Linting
 
-on:
-  push:
-    branches: ['release/stacking']
-  pull_request:
-    branches: ['release/stacking']
+on: [push]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Testing
 
-on:
-  push:
-    branches: ['release/stacking']
-  pull_request:
-    branches: ['release/stacking']
+on: [push]
 
 jobs:
   test:

--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -31,9 +31,12 @@ export class Api {
     );
   }
 
-  async getFaucetStx(address: string) {
+  async getFaucetStx(address: string, stacking?: boolean) {
     return axios.post(
-      urljoin(this.baseUrl, `/extended/v1/faucets/stx?address=${address}&stacking=true`)
+      urljoin(
+        this.baseUrl,
+        `/extended/v1/faucets/stx?address=${address}${stacking ? '&stacking=true' : ''}`
+      )
     );
   }
 

--- a/app/components/beta-notice.tsx
+++ b/app/components/beta-notice.tsx
@@ -5,10 +5,12 @@ import { openExternalLink } from '@utils/external-links';
 import packageJson from '../../package.json';
 
 const sha = process.env.SHA;
-const buildDate = process.env.BUILD_DATE;
+const shaShort = sha && sha.substr(0, 7);
+const pullRequest = process.env.PULL_REQUEST;
+const branchName = process.env.BRANCH_NAME;
+const version = packageJson.version;
 
 const issueParams = new URLSearchParams();
-
 const issueTitle = `[${String(packageJson.version)}] Bug: <describe issue>`;
 const issueLabels = 'bug,reported-from-ui';
 const issueBody = `
@@ -21,7 +23,7 @@ const issueBody = `
 
 -->
 
-Bug found testing Stacks Wallet build ${String(sha)}, ${String(buildDate)}.
+Bug found testing Stacks Wallet build ${String(shaShort)}, ${String(version)}.
 
 `;
 
@@ -30,12 +32,14 @@ issueParams.set('labels', issueLabels);
 issueParams.set('body', issueBody);
 
 const openIssueLink = () =>
-  openExternalLink(
-    `https://github.com/blockstack/stacks-wallet/issues/new?${issueParams.toString()}`
-  );
+  openExternalLink(`https://github.com/blockstack/stacks-wallet/issues/new?${String(issueParams)}`);
+
+const openPullRequestLink = () =>
+  openExternalLink(`https://github.com/blockstack/stacks-wallet/pull/${String(pullRequest)}`);
 
 export const BetaNotice: FC = () => {
-  if (!sha && !buildDate) return null;
+  if (!sha && !version.includes('beta')) return null;
+
   return (
     <Flex
       textStyle="caption.medium"
@@ -45,24 +49,34 @@ export const BetaNotice: FC = () => {
       bottom="base"
       flexDirection={['column', 'row']}
     >
-      <Text mr="base" onClick={openIssueLink} textDecoration="underline" cursor="pointer">
+      <Text mr="base-tight" onClick={openIssueLink} textDecoration="underline" cursor="pointer">
         Found a bug? Open an issue
       </Text>
-      {/* <Text mr="base">
-        Commit:{' '}
+      {pullRequest && branchName && (
         <Text
-          cursor="pointer"
+          mr="base-tight"
+          onClick={openPullRequestLink}
           textDecoration="underline"
-          onClick={() =>
-            openExternalLink(
-              `https://github.com/blockstack/stacks-wallet/pull/203/commits/${sha || ''}`
-            )
-          }
+          cursor="pointer"
         >
-          {sha}
+          {branchName}
         </Text>
-      </Text> */}
-      <Text mr="base">Build date: {buildDate}</Text>
+      )}
+      {shaShort && (
+        <Text mr="base">
+          Commit:{' '}
+          <Text
+            cursor="pointer"
+            textDecoration="underline"
+            onClick={() =>
+              openExternalLink(`https://github.com/blockstack/stacks-wallet/commit/${sha || ''}`)
+            }
+          >
+            {shaShort}
+          </Text>
+        </Text>
+      )}
+      <Text mr="base">[{packageJson.version}]</Text>
     </Flex>
   );
 };

--- a/app/components/home/balance-card.tsx
+++ b/app/components/home/balance-card.tsx
@@ -70,6 +70,7 @@ export const BalanceCard: FC<BalanceCardProps> = props => {
             ml="tight"
             isDisabled={requestingTestnetStx}
             onClick={e => requestTestnetStacks(e)}
+            title="Hold alt to request more STX. Use sparingly."
           >
             <Box
               mr="extra-tight"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stacks-wallet",
   "productName": "Stacks Wallet",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-beta.6",
   "description": "",
   "main": "./main.prod.js",
   "author": {

--- a/app/pages/home/home.tsx
+++ b/app/pages/home/home.tsx
@@ -137,7 +137,9 @@ export const Home: FC = () => {
       balance={balance}
       onSelectSend={() => dispatch(homeActions.openTxModal())}
       onSelectReceive={() => dispatch(homeActions.openReceiveModal())}
-      onRequestTestnetStx={async () => new Api(activeNode.url).getFaucetStx(address)}
+      onRequestTestnetStx={async ({ stacking }) =>
+        new Api(activeNode.url).getFaucetStx(address, stacking)
+      }
     />
   );
 

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -64,6 +64,7 @@ export default {
   plugins: [
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'production',
+      SHA: '',
     }),
 
     new webpack.NamedModulesPlugin(),

--- a/configs/webpack.config.main.prod.babel.js
+++ b/configs/webpack.config.main.prod.babel.js
@@ -65,8 +65,6 @@ export default merge.smart(baseConfig, {
       DEBUG_PROD: false,
       START_MINIMIZED: false,
       E2E_BUILD: false,
-      SHA: process.env.SHA,
-      BUILD_DATE: process.env.BUILD_DATE,
     }),
   ],
 

--- a/configs/webpack.config.renderer.dev.babel.js
+++ b/configs/webpack.config.renderer.dev.babel.js
@@ -135,6 +135,7 @@ export default merge.smart(baseConfig, {
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development',
       STX_NETWORK: 'testnet',
+      SHA: '',
     }),
 
     new webpack.LoaderOptionsPlugin({

--- a/configs/webpack.config.renderer.prod.babel.js
+++ b/configs/webpack.config.renderer.prod.babel.js
@@ -116,8 +116,6 @@ export default merge.smart(baseConfig, {
       DEBUG_PROD: false,
       STX_NETWORK: 'testnet',
       E2E_BUILD: false,
-      SHA: process.env.SHA,
-      BUILD_DATE: process.env.BUILD_DATE,
     }),
 
     new BundleAnalyzerPlugin({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stacks-wallet",
   "productName": "Stacks Wallet",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-beta.6",
   "description": "Stacks Wallet 2.0 — Stacking",
   "prettier": "@blockstack/prettier-config",
   "author": {


### PR DESCRIPTION
> [Download the latest builds [4.0.0-beta.6]](https://github.com/blockstack/stacks-wallet/actions/runs/341854605).<!-- Sticky Header Marker -->

That's the last time I use vscode built-in git. Checked out this pr blockstack/stacks-wallet#303 it the branch via git panel, had only a single commit with the entire tree in it, so a commit amend gone done broked stuff 🤔 🥴

This PR makes some changes to the CI task and adds some (very) simple error handling for faucet, and only sends a stacking faucet request when clicking the button while holding <kbd>alt</kbd>