### PR TITLE
fix: use clearer password messaging, closes #260

### DIFF
--- a/app/pages/onboarding/07-set-password/set-password.tsx
+++ b/app/pages/onboarding/07-set-password/set-password.tsx
@@ -22,11 +22,14 @@ const weakPasswordWarningMessage = (result: ValidatedPassword) => {
   if (result.feedback.suggestions.length > 0) {
     return `${result.feedback.suggestions.join(' ')}`;
   }
+  if (result.feedback.warning) {
+    return `${result.feedback.warning}`;
+  }
   if (!result.meetsScoreRequirement) {
-    return 'Your password is vulnerable to brute force attacks. Try using a stronger password at least 12 characters in length';
+    return 'Your password is vulnerable to brute force attacks. Try adding more non-alphanumeric characters.';
   }
   if (!result.meetsLengthRequirement) {
-    return 'Your password must also be at least 12 characters long.';
+    return 'Your password must be at least 12 characters long';
   }
   return 'Consider using a password generator to ensure your funds are sufficiently secure';
 };


### PR DESCRIPTION
> [Download the latest builds [4.0.0-beta.7]](https://github.com/blockstack/stacks-wallet/actions/runs/393883340).<!-- Sticky Header Marker -->

Adjusted the password messaging to avoid circumstance where we advise someone to use a 12 char pw when they already are.

I think what we have now works quite well. zxcvbn library provides a handful of useful warnings if you're using a useless password, and we have generic guidance if it doesn't meet the criteria and there's no suggestions.