### PR TITLE
fix(stacking): allow testnet btc address in testnet mode

### DIFF
--- a/app/pages/stacking/step/choose-btc-address.tsx
+++ b/app/pages/stacking/step/choose-btc-address.tsx
@@ -5,7 +5,7 @@ import validate from 'bitcoin-address-validation';
 
 import { ErrorText } from '@components/error-text';
 import { ErrorLabel } from '@components/error-label';
-import { SUPPORTED_BTC_ADDRESS_FORMATS } from '../../../constants/index';
+import { NETWORK, SUPPORTED_BTC_ADDRESS_FORMATS } from '@constants/index';
 
 import {
   StackingStep,
@@ -30,7 +30,9 @@ export const ChooseBtcAddressStep: FC<ChooseBtcAddressStepProps> = props => {
     validate: ({ btcAddress }) => {
       const address = validate(btcAddress);
       if (!address) return { btcAddress: 'Invalid BTC address' };
-      if (address.network === 'testnet') return { btcAddress: 'Testnet addresses not supported' };
+      if (NETWORK === 'mainnet' && address.network === 'testnet') {
+        return { btcAddress: 'Testnet addresses not supported' };
+      }
       // https://github.com/blockstack/stacks-blockchain/issues/1902
       if (!SUPPORTED_BTC_ADDRESS_FORMATS.includes(address.type as any)) {
         return {

--- a/app/pages/stacking/step/choose-btc-address.tsx
+++ b/app/pages/stacking/step/choose-btc-address.tsx
@@ -31,7 +31,7 @@ export const ChooseBtcAddressStep: FC<ChooseBtcAddressStepProps> = props => {
       const address = validate(btcAddress);
       if (!address) return { btcAddress: 'Invalid BTC address' };
       if (NETWORK === 'mainnet' && address.network === 'testnet') {
-        return { btcAddress: 'Testnet addresses not supported' };
+        return { btcAddress: 'Testnet addresses not supported on Mainnet' };
       }
       // https://github.com/blockstack/stacks-blockchain/issues/1902
       if (!SUPPORTED_BTC_ADDRESS_FORMATS.includes(address.type as any)) {

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "browserslist-config-erb": "0.0.1",
     "chalk": "4.1.0",
     "circular-dependency-plugin": "5.2.2",
+    "concat-map": "0.0.1",
     "concurrently": "5.3.0",
     "copy-webpack-plugin": "6.3.0",
     "cross-env": "7.0.2",


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/460758495)<!-- Sticky Header Marker -->

This PR changes validation logic so that testnet BTC addresses are only prohibited in mainnet mode. This follows a change to the PoX contract that handles mainnet/testnet behaviours differently.