### PR TITLE
chore: add windows code-signing

### DIFF
--- a/.github/workflows/stacks-wallet.yml
+++ b/.github/workflows/stacks-wallet.yml
@@ -94,12 +94,18 @@ jobs:
         include:
           - os: macos-latest
             NPM_COMMAND: mac
+            CSC_LINK: ''
+            CSC_KEY_PASSWORD: ''
 
           - os: ubuntu-latest
             NPM_COMMAND: linux
+            CSC_LINK: ''
+            CSC_KEY_PASSWORD: ''
 
           - os: windows-latest
             NPM_COMMAND: win
+            CSC_LINK: ${{ secrets.CODE_SIGNING_CERTIFICATE_WINDOWS }}
+            CSC_KEY_PASSWORD: ${{ secrets.CODE_SIGNING_PASSWORD_WINDOWS }}
 
     steps:
       - name: Cancel Previous Runs
@@ -145,6 +151,8 @@ jobs:
           PULL_REQUEST: ${{ steps.vars.outputs.pull_request_id }}
           BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
           STX_NETWORK: testnet
+          CSC_LINK: ${{ matrix.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ matrix.CSC_KEY_PASSWORD }}
 
       - uses: actions/upload-artifact@v2
         name: Windows upload


### PR DESCRIPTION
Adds code-signing to the build process.

Closes https://github.com/blockstackpbc/devops/issues/516
Closes https://github.com/blockstack/stacks-wallet/issues/304

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
