### PR TITLE
Feat/code signing

### DIFF
--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -13,12 +13,16 @@ jobs:
         include:
           - os: macos-latest
             NPM_COMMAND: mac
+            CSC_LINK_SECRET_NAME: CODE_SIGNING_CERTIFICATE_APPLE
+            CSC_KEY_PASSWORD_SECRET_NAME: CODE_SIGNING_PASSWORD_APPLE
 
           - os: ubuntu-latest
             NPM_COMMAND: linux
 
           - os: windows-latest
             NPM_COMMAND: win
+            CSC_LINK_SECRET_NAME: CODE_SIGNING_CERTIFICATE_WINDOWS
+            CSC_KEY_PASSWORD_SECRET_NAME: CODE_SIGNING_PASSWORD_WINDOWS
 
     steps:
       - name: Check out Git repository
@@ -37,12 +41,20 @@ jobs:
           echo "GITHUB_REF_NAME_SLUG=$GITHUB_REF_NAME_SLUG"
           echo "GITHUB_SHA_SHORT=$GITHUB_SHA_SHORT"
           echo "GITHUB_SHA=$GITHUB_SHA"
+
       - name: Variables
         id: vars
         run: |
           echo "::set-output name=version::$(cat package.json | jq -r .version)"
           echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/})"
           echo "::set-output name=pull_request_id::$(echo $GITHUB_REF)"
+
+      - name: Install code-signing certs - Apple only
+        uses: apple-actions/import-codesign-certs@v1
+        if: matrix.os == 'macos-latest'
+        with:
+          p12-file-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE_APPLE }}
+          p12-password: ${{ secrets.CODE_SIGNING_PASSWORD_APPLE }}
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
@@ -70,6 +82,10 @@ jobs:
           PULL_REQUEST: ${{ steps.vars.outputs.pull_request_id }}
           BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
           STX_NETWORK: ${{ matrix.stx_network }}
+          CSC_LINK: ${{ secrets[matrix.CSC_LINK_SECRET_NAME] }}
+          CSC_KEY_PASSWORD: ${{ secrets[matrix.CSC_KEY_PASSWORD_SECRET_NAME] }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
 
       - run: ls -R release
 

--- a/.github/workflows/stacks-wallet.yml
+++ b/.github/workflows/stacks-wallet.yml
@@ -94,12 +94,16 @@ jobs:
         include:
           - os: macos-latest
             NPM_COMMAND: mac
+            CSC_LINK_SECRET_NAME: CODE_SIGNING_CERTIFICATE_APPLE
+            CSC_KEY_PASSWORD_SECRET_NAME: CODE_SIGNING_PASSWORD_APPLE
 
           - os: ubuntu-latest
             NPM_COMMAND: linux
 
           - os: windows-latest
             NPM_COMMAND: win
+            CSC_LINK_SECRET_NAME: CODE_SIGNING_CERTIFICATE_WINDOWS
+            CSC_KEY_PASSWORD_SECRET_NAME: CODE_SIGNING_PASSWORD_WINDOWS
 
     steps:
       - name: Cancel Previous Runs
@@ -119,6 +123,13 @@ jobs:
           echo "::set-output name=branch_name::$(echo ${GITHUB_REF#refs/heads/})"
           echo "::set-output name=pull_request_id::$(echo $GITHUB_REF)"
 
+      - name: Install code-signing certs - Apple only
+        uses: apple-actions/import-codesign-certs@v1
+        if: matrix.os == 'macos-latest'
+        with:
+          p12-file-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE_APPLE }}
+          p12-password: ${{ secrets.CODE_SIGNING_PASSWORD_APPLE }}
+
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
@@ -137,7 +148,7 @@ jobs:
         env:
           STX_NETWORK: testnet
 
-      - name: Install `concat-map` only for Windows
+      - name: Install `concat-map` - Windows only
         run: yarn add concat-map --ignore-scripts --frozen-lockfile
         if: matrix.os == 'windows-latest'
         env:
@@ -151,6 +162,10 @@ jobs:
           PULL_REQUEST: ${{ steps.vars.outputs.pull_request_id }}
           BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
           STX_NETWORK: testnet
+          CSC_LINK: ${{ secrets[matrix.CSC_LINK_SECRET_NAME] }}
+          CSC_KEY_PASSWORD: ${{ secrets[matrix.CSC_KEY_PASSWORD_SECRET_NAME] }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
 
       - uses: actions/upload-artifact@v2
         name: Windows upload

--- a/app/hooks/use-ledger.ts
+++ b/app/hooks/use-ledger.ts
@@ -11,6 +11,9 @@ export enum LedgerConnectStep {
   HasAddress,
 }
 
+const SAFE_ASSUME_REAL_DEVICE_DISCONNECT_TIME = 1000;
+const POLL_LEDGER_INTERVAL = 250;
+
 export function useLedger() {
   const [step, setStep] = useState(LedgerConnectStep.Disconnected);
   const [usbError, setUsbError] = useState<string | null>(null);
@@ -19,8 +22,6 @@ export function useLedger() {
   const listeningForAddEvent = useRef(true);
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const closeTransport = useRef(() => {});
-  const SAFE_ASSUME_REAL_DEVICE_DISCONNECT_TIME = 1000;
-  const POLL_LEDGER_INTERVAL = 250;
   const createListener = useCallback(() => {
     const tHid = api.nodeHid.listen({
       next: async (event: any) => {

--- a/app/modals/receive-stx/receive-stx-modal.tsx
+++ b/app/modals/receive-stx/receive-stx-modal.tsx
@@ -1,13 +1,28 @@
-import React, { FC } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { FC, useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHotkeys } from 'react-hotkeys-hook';
 import Qr from 'qrcode.react';
-import { Text, Modal, Button, Flex, Box, useClipboard } from '@blockstack/ui';
+import {
+  Text,
+  Modal,
+  Button,
+  Flex,
+  Box,
+  useClipboard,
+  ExclamationMarkCircleIcon,
+} from '@blockstack/ui';
 
-import { NETWORK } from '@constants/index';
-import { homeActions } from '@store/home/home.reducer';
-import { TxModalHeader, TxModalFooter } from '../transaction/transaction-modal-layout';
+import { RootState } from '@store/index';
+import { selectWalletType } from '@store/keys';
+import { homeActions } from '@store/home';
+import { useLedger, LedgerConnectStep } from '@hooks/use-ledger';
+
+import { NETWORK, STX_DERIVATION_PATH } from '@constants/index';
 import { ExchangeWithdrawalWarning } from '@components/testnet/exchange-withdrawal-warning';
+import { TxModalHeader, TxModalFooter } from '../transaction/transaction-modal-layout';
+import { LedgerConnectInstructions } from '@components/ledger/ledger-connect-instructions';
+import { delay } from '@utils/delay';
+import BlockstackApp from '@zondax/ledger-blockstack';
 
 interface ReceiveStxModalProps {
   address: string;
@@ -16,8 +31,41 @@ interface ReceiveStxModalProps {
 export const ReceiveStxModal: FC<ReceiveStxModalProps> = ({ address }) => {
   const dispatch = useDispatch();
   useHotkeys('esc', () => void dispatch(homeActions.closeReceiveModal()));
+  const [view, setView] = useState<'main' | 'verify-ledger'>('main');
+  const [ledgerAddress, setLedgerAddress] = useState<null | string>(null);
+  const [isWaitingLedger, setIsWaitingLedger] = useState(false);
   const { hasCopied, onCopy } = useClipboard(address);
   const closeModal = () => dispatch(homeActions.closeReceiveModal());
+
+  const { walletType } = useSelector((state: RootState) => ({
+    walletType: selectWalletType(state),
+  }));
+
+  const { transport, step } = useLedger();
+
+  const verifyAddress = useCallback(async () => {
+    const usbTransport = transport;
+    if (usbTransport === null) return;
+    setIsWaitingLedger(true);
+
+    const app = new BlockstackApp(usbTransport);
+
+    try {
+      await app.getVersion();
+      await delay(1);
+      const resp = await app.showAddressAndPubKey(STX_DERIVATION_PATH);
+      if (resp && resp.address) {
+        setLedgerAddress(resp.address);
+      }
+      setIsWaitingLedger(false);
+    } catch (e) {
+      console.log(e);
+      setIsWaitingLedger(false);
+    }
+  }, [transport]);
+
+  const stepToShow = address === ledgerAddress ? LedgerConnectStep.HasAddress : step;
+
   return (
     <Modal
       minWidth="488px"
@@ -32,13 +80,55 @@ export const ReceiveStxModal: FC<ReceiveStxModalProps> = ({ address }) => {
       }
     >
       <Flex flexDirection="column" alignItems="center" mx="extra-loose">
-        <Box border="1px solid #F0F0F5" p="base" mt="extra-loose" borderRadius="8px">
-          <Qr value={address} shapeRendering="sharp-edges" />
-        </Box>
-        <Text textStyle="body.large.medium" mt="loose">
-          Wallet address
-        </Text>
         {NETWORK === 'testnet' && <ExchangeWithdrawalWarning />}
+        {view === 'main' && (
+          <>
+            <Box border="1px solid #F0F0F5" p="base" mt="base" borderRadius="8px">
+              <Qr value={address} shapeRendering="sharp-edges" />
+            </Box>
+            <Text textStyle="body.large.medium" mt="loose">
+              Wallet address
+            </Text>
+          </>
+        )}
+        {view === 'verify-ledger' && (
+          <Flex flexDirection="column" width="80%" mb="base-tight">
+            <LedgerConnectInstructions action="Verify address" step={stepToShow} />
+            <Button
+              mode="secondary"
+              mt="base"
+              mx="extra-loose"
+              isDisabled={step < LedgerConnectStep.ConnectedAppOpen}
+              isLoading={isWaitingLedger}
+              onClick={verifyAddress}
+            >
+              Request Ledger address
+            </Button>
+            {ledgerAddress !== null && ledgerAddress !== address && (
+              <Flex
+                backgroundColor="#FCEBEC"
+                width="100%"
+                borderRadius="6px"
+                padding="base"
+                mt="tight"
+                pr="base-loose"
+              >
+                <ExclamationMarkCircleIcon
+                  color="#CF0000"
+                  width="16px"
+                  height="16px"
+                  minWidth="16px"
+                  mr="tight"
+                  mt="1px"
+                />
+                <Text textStyle="body.small">
+                  The addresses do not match. Make sure you're using the Ledger device with which
+                  you created this wallet.
+                </Text>
+              </Flex>
+            )}
+          </Flex>
+        )}
         <Flex
           mt="base-tight"
           justifyContent="center"
@@ -52,9 +142,16 @@ export const ReceiveStxModal: FC<ReceiveStxModalProps> = ({ address }) => {
             {address}
           </Text>
         </Flex>
-        <Button variant="link" mt="tight" mb="loose" onClick={onCopy}>
-          {hasCopied ? 'Copied' : 'Copy address'}
-        </Button>
+        <Box mb="loose" mt="base">
+          <Button variant="link" onClick={onCopy} mr="tight">
+            {hasCopied ? 'Copied' : 'Copy address'}
+          </Button>
+          {walletType === 'ledger' && (
+            <Button variant="link" onClick={() => setView('verify-ledger')}>
+              Verify Ledger address
+            </Button>
+          )}
+        </Box>
       </Flex>
     </Modal>
   );

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -10,6 +10,7 @@ if (!['mainnet', 'testnet'].includes(process.env.STX_NETWORK)) {
 }
 
 const baseConfig = {
+  afterSign: "scripts/notarize.js",
   files: [
     'dist/',
     'node_modules/',
@@ -37,7 +38,7 @@ const baseConfig = {
     target: ['nsis', 'msi'],
   },
   mac: {
-    hardenedRuntime: false,
+    hardenedRuntime: true,
     category: 'public.app-category.finance',
   },
   linux: {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "electron": "8.5.2",
     "electron-builder": "22.8.0",
     "electron-devtools-installer": "3.0.0",
+    "electron-notarize": "1.0.0",
     "electron-rebuild": "1.11.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.5",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,18 @@
+const { notarize } = require('electron-notarize');
+const appId = require('../electron-builder.js').appId
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;  
+  if (electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+
+  return await notarize({
+    appBundleId: `${appId}`,
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_ID_PASS,
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,6 +5280,14 @@ electron-log@4.2.2:
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.2.2.tgz#b358dc6d1e4772465609ee3d8ad9f594d9e742c8"
   integrity sha512-lBpLh1Q8qayrTxFIrTPcNjSHsosvUfOYyZ8glhiLcx7zCNPDGuj8+nXlEaaSS6LRiQQbLgLG+wKpuvztNzBIrA==
 
+electron-notarize@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-1.0.0.tgz#bc925b1ccc3f79e58e029e8c4706572b01a9fd8f"
+  integrity sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+
 electron-publish@22.8.0:
   version "22.8.0"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.8.0.tgz#7f410fe043abc5d3d896c4ee9eea7a43ea352c7d"


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/468352760)<!-- Sticky Header Marker -->

* Adds code-signing to the Windows and OSX apps
* Notarizes the OSX app
* Confirmed on Big Sur I can install a signed + notarized DMG, while I was unable to install an unsigned + not notarized DMG recently created from the `beta` branch.

Some reference documentation:
https://www.electron.build/code-signing
https://github.com/electron/electron-notarize
https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/

Closes https://github.com/blockstackpbc/devops/issues/516
Closes https://github.com/blockstack/stacks-wallet/issues/304

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Checklist
- [X] `npm run test` passes
- [X] Tag 1 of @kyranjamie 