### PR TITLE
fix: wiping a corrupt wallet file

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -21,10 +21,12 @@ import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import windowState from 'electron-window-state';
 import contextMenu from 'electron-context-menu';
+import Store from 'electron-store';
+
 import MenuBuilder from './menu';
 import { deriveKey } from './crypto/key-generation';
-import Store from 'electron-store';
 import { NETWORK } from './constants/index';
+import { validateConfig } from './main/validate-config';
 
 // CSP enabled in production mode, don't warn in development
 delete process.env.ELECTRON_ENABLE_SECURITY_WARNINGS;
@@ -178,7 +180,11 @@ app.on('activate', () => {
   if (mainWindow === null) void createWindow();
 });
 
-const store = new Store();
+validateConfig(app);
+
+const store = new Store({
+  clearInvalidConfig: true,
+});
 
 ipcMain.handle('store-set', (_e, { key, value }: any) => store.set(key, value));
 ipcMain.handle('store-get', (_e, { key }: any) => store.get(key));

--- a/app/main/validate-config.ts
+++ b/app/main/validate-config.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { App } from 'electron';
+
+export function validateConfig(app: App) {
+  const configPath = path.join(app.getPath('userData'), 'config.json');
+  fs.readFile(configPath, 'utf8', (err, walletConfigText) => {
+    if (err) return;
+    try {
+      JSON.parse(walletConfigText);
+    } catch (e) {
+      console.log('Backing up wallet');
+      const now = new Date().toISOString();
+      const corruptFilePath = path.join(
+        app.getPath('userData'),
+        `corrupt-wallet-backup-${now}.txt`
+      );
+      fs.writeFile(corruptFilePath, walletConfigText, err => {
+        if (err) return;
+      });
+    }
+  });
+}


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/476054810)<!-- Sticky Header Marker -->

This is a bit of an edge case, but that could result in a loss of wallet data.

Consider a user that loses their seed phrase, and only has the config.json as their backup. They go and find the config file, accidentally delete 1 char rendering it invalid JSON and load the wallet.

Improbable though that might be, the wallet currently just wipes the file. This'd be fine if you have your seed phrase, but if you don't you'd lose your only remaining copy. The wallet should never delete a config like this, even if invalid.

See implementation, but this basically first checks if the JSON is valid, if not, makes a back up. Store will then parse and wipe that file.

@timstackblock or @markmhx would really appreciate QA of this. To test:
- Install a mainnet or testnet build
- Create a wallet and expect to see a file in `cat ~/Library/Application\ Support/StacksWalletTestnet/config.json`
- Modify/break/make a syntax error in this file and open the wallet
- Check `ls -la ~/Library/Application\ Support/StacksWalletTestnet/` and expect to find a new file with the corrupt wallet data