### PR TITLE
refactor: safter network switching logic

### DIFF
--- a/app/components/home/balance-card.tsx
+++ b/app/components/home/balance-card.tsx
@@ -8,6 +8,7 @@ import { delay } from '@utils/delay';
 import BN from 'bn.js';
 import { ExternalLink } from '@components/external-link';
 import { makeExplorerAddressLink } from '@utils/external-links';
+import { isTestnet } from '@utils/network-utils';
 
 interface BalanceCardProps {
   balance: string | null;
@@ -73,7 +74,7 @@ export const BalanceCard: FC<BalanceCardProps> = props => {
           <ArrowIcon direction="down" mr="base-tight" />
           Receive
         </Button>
-        {NETWORK === 'testnet' && (
+        {isTestnet() && (
           <Button
             mode="secondary"
             size="md"

--- a/app/components/title-bar/network-message.tsx
+++ b/app/components/title-bar/network-message.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
 import { Text, Box } from '@blockstack/ui';
 
-import { NETWORK } from '@constants/index';
+import { isMainnet } from '@utils/network-utils';
 
 interface NetworkMessageProps {
   textColor?: string;
 }
 
 export const NetworkMessage: FC<NetworkMessageProps> = ({ textColor }) => {
-  if (NETWORK === 'mainnet') return null;
+  if (isMainnet()) return null;
   return (
     <Box top="9px">
       <Box display={['none', 'block']} pl="base" position="relative">

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -1,4 +1,5 @@
 import packageJson from '../../package.json';
+import { whenNetwork } from '../utils/network-utils';
 
 type Environments = 'development' | 'testing' | 'production';
 
@@ -24,8 +25,10 @@ export const STATUS_PAGE_URL = 'http://status.test-blockstack.com';
 
 export const DEFAULT_STACKS_NODE_URL = 'https://stacks-node-api.blockstack.org';
 
-export const EXPLORER_URL =
-  NETWORK === 'testnet' ? 'https://testnet-explorer.blockstack.org' : 'https://explorer.stacks.co';
+export const EXPLORER_URL = whenNetwork<string>({
+  mainnet: 'https://explorer.stacks.co',
+  testnet: 'https://testnet-explorer.blockstack.org',
+});
 
 export const GITHUB_ORG = 'blockstack';
 

--- a/app/environment.ts
+++ b/app/environment.ts
@@ -1,10 +1,12 @@
 import { ChainID } from '@stacks/transactions';
 import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
-import { NETWORK } from './constants';
+import { whenNetwork } from './utils/network-utils';
 
 export { ChainID };
 
-export const chain = NETWORK === 'testnet' ? ChainID.Testnet : ChainID.Mainnet;
+export const chain = whenNetwork<ChainID>({ testnet: ChainID.Testnet, mainnet: ChainID.Mainnet });
 
-export const stacksNetwork: StacksNetwork =
-  NETWORK === 'testnet' ? new StacksTestnet() : new StacksMainnet();
+export const stacksNetwork = whenNetwork<StacksNetwork>({
+  mainnet: new StacksMainnet(),
+  testnet: new StacksTestnet(),
+});

--- a/app/modals/receive-stx/receive-stx-modal.tsx
+++ b/app/modals/receive-stx/receive-stx-modal.tsx
@@ -12,17 +12,18 @@ import {
   ExclamationMarkCircleIcon,
 } from '@blockstack/ui';
 
+import BlockstackApp from '@zondax/ledger-blockstack';
+import { isTestnet } from '@utils/network-utils';
 import { RootState } from '@store/index';
 import { selectWalletType } from '@store/keys';
 import { homeActions } from '@store/home';
 import { useLedger, LedgerConnectStep } from '@hooks/use-ledger';
 
-import { NETWORK, STX_DERIVATION_PATH } from '@constants/index';
+import { STX_DERIVATION_PATH } from '@constants/index';
 import { ExchangeWithdrawalWarning } from '@components/testnet/exchange-withdrawal-warning';
 import { TxModalHeader, TxModalFooter } from '../transaction/transaction-modal-layout';
 import { LedgerConnectInstructions } from '@components/ledger/ledger-connect-instructions';
 import { delay } from '@utils/delay';
-import BlockstackApp from '@zondax/ledger-blockstack';
 
 interface ReceiveStxModalProps {
   address: string;
@@ -80,7 +81,7 @@ export const ReceiveStxModal: FC<ReceiveStxModalProps> = ({ address }) => {
       }
     >
       <Flex flexDirection="column" alignItems="center" mx="extra-loose">
-        {NETWORK === 'testnet' && <ExchangeWithdrawalWarning />}
+        {isTestnet() && <ExchangeWithdrawalWarning />}
         {view === 'main' && (
           <>
             <Box border="1px solid #F0F0F5" p="base" mt="base" borderRadius="8px">

--- a/app/modals/stacking/stacking-modal.tsx
+++ b/app/modals/stacking/stacking-modal.tsx
@@ -6,11 +6,10 @@ import BlockstackApp, { LedgerError, ResponseSign } from '@zondax/ledger-blockst
 import { useHotkeys } from 'react-hotkeys-hook';
 import { BigNumber } from 'bignumber.js';
 import { StackingClient } from '@stacks/stacking';
-import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import BN from 'bn.js';
 
 import { RootState } from '@store/index';
-import { NETWORK, STX_DERIVATION_PATH } from '@constants/index';
+import { STX_DERIVATION_PATH } from '@constants/index';
 import routes from '@constants/routes.json';
 import {
   selectPublicKey,
@@ -43,6 +42,7 @@ import { DecryptWalletForm } from './steps/decrypt-wallet-form';
 import { SignTxWithLedger } from './steps/sign-tx-with-ledger';
 import { StackingFailed } from './steps/stacking-failed';
 import { delay } from '@utils/delay';
+import { stacksNetwork } from '../../environment';
 
 enum StackingModalStep {
   DecryptWalletAndSend,
@@ -101,7 +101,7 @@ export const StackingModal: FC<StackingModalProps> = props => {
   const [step, setStep] = useState(initialStep);
 
   const initStackingClient = useCallback(() => {
-    const network = NETWORK === 'mainnet' ? new StacksMainnet() : new StacksTestnet();
+    const network = stacksNetwork;
     network.coreApiUrl = node.url;
     return new StackingClient(poxAddress, network as any);
   }, [node.url, poxAddress]);

--- a/app/modals/transaction/transaction-modal.tsx
+++ b/app/modals/transaction/transaction-modal.tsx
@@ -56,7 +56,7 @@ import { SignTxWithLedger } from './steps/sign-tx-with-ledger';
 import { FailedBroadcastError } from './steps/failed-broadcast-error';
 import { PreviewTransaction } from './steps/preview-transaction';
 import { StacksTestnet } from '@stacks/network';
-import { validateDecimalPrecision } from '../../utils/form/validate-decimals';
+import { validateDecimalPrecision } from '@utils/form/validate-decimals';
 import { PostCoreNodeTransactionsError } from '@blockstack/stacks-blockchain-api-types';
 
 interface TxModalProps {

--- a/app/pages/onboarding/02-create-wallet/create-wallet.tsx
+++ b/app/pages/onboarding/02-create-wallet/create-wallet.tsx
@@ -14,7 +14,8 @@ import {
 } from '@components/onboarding';
 import { useBackButton } from '@hooks/use-back-url';
 import { openExternalLink } from '@utils/external-links';
-import { TREZOR_HELP_URL, NETWORK } from '@constants/index';
+import { TREZOR_HELP_URL } from '@constants/index';
+import { isMainnet } from '@utils/network-utils';
 
 export const CreateWallet: React.FC = () => {
   const dispatch = useDispatch();
@@ -35,7 +36,7 @@ export const CreateWallet: React.FC = () => {
         Please choose whether you’d like to connect a Ledger hardware wallet or to create a software
         wallet
       </OnboardingText>
-      {NETWORK === 'mainnet' && (
+      {isMainnet() && (
         <OnboardingButton mt="extra-loose" onClick={() => history.push(routes.CONNECT_LEDGER)}>
           Use a Ledger wallet
         </OnboardingButton>

--- a/app/pages/onboarding/04-connect-ledger/connect-ledger.tsx
+++ b/app/pages/onboarding/04-connect-ledger/connect-ledger.tsx
@@ -19,6 +19,7 @@ import { useLedger } from '@hooks/use-ledger';
 import { ErrorLabel } from '@components/error-label';
 import { ErrorText } from '@components/error-text';
 import { useBackButton } from '@hooks/use-back-url';
+import { isMainnet } from '@utils/network-utils';
 
 export enum LedgerConnectStep {
   Disconnected,
@@ -70,7 +71,7 @@ export const ConnectLedger: React.FC = () => {
         setHasConfirmedAddress(true);
         await delay(750);
 
-        if (CONFIG.STX_NETWORK === 'mainnet' && !confirmedResponse.address.startsWith('SP')) {
+        if (isMainnet() && !confirmedResponse.address.startsWith('SP')) {
           setLedgerLaunchVersionError(
             'Make sure you have the most recent version of Ledger app. Address generated is for testnet'
           );

--- a/app/pages/stacking/step/choose-btc-address.tsx
+++ b/app/pages/stacking/step/choose-btc-address.tsx
@@ -5,7 +5,8 @@ import validate from 'bitcoin-address-validation';
 
 import { ErrorText } from '@components/error-text';
 import { ErrorLabel } from '@components/error-label';
-import { NETWORK, SUPPORTED_BTC_ADDRESS_FORMATS } from '@constants/index';
+import { SUPPORTED_BTC_ADDRESS_FORMATS } from '@constants/index';
+import { isMainnet, isTestnet } from '@utils/network-utils';
 import { StackingStepState } from '../stacking';
 
 import {
@@ -32,10 +33,10 @@ export const ChooseBtcAddressStep: FC<ChooseBtcAddressStepProps> = props => {
     validate: ({ btcAddress }) => {
       const address = validate(btcAddress);
       if (!address) return { btcAddress: 'Invalid BTC address' };
-      if (NETWORK === 'mainnet' && address.network === 'testnet') {
+      if (isMainnet() && address.network === 'testnet') {
         return { btcAddress: 'Testnet addresses not supported on Mainnet' };
       }
-      if (NETWORK === 'testnet' && address.network !== 'testnet') {
+      if (isTestnet() && address.network !== 'testnet') {
         return { btcAddress: 'Mainnet addresses not supported on Testnet' };
       }
       // https://github.com/blockstack/stacks-blockchain/issues/1902

--- a/app/store/stacking/stacking.actions.ts
+++ b/app/store/stacking/stacking.actions.ts
@@ -1,12 +1,11 @@
 import { createAsyncThunk, createAction } from '@reduxjs/toolkit';
 import { StackingClient } from '@stacks/stacking';
-import { StacksMainnet, StacksTestnet } from '@stacks/network';
 
-import { NETWORK } from '@constants/index';
 import { selectActiveNodeApi } from '@store/stacks-node/stacks-node.reducer';
 import { RootState } from '@store/index';
 import { Api } from '@api/api';
 import { safeAwait } from '@utils/safe-await';
+import { stacksNetwork } from '../../environment';
 
 export const fetchStackingInfo = createAsyncThunk('stacking/details', async (_arg, thunkApi) => {
   const state = thunkApi.getState() as RootState;
@@ -39,7 +38,7 @@ export const fetchStackerInfo = createAsyncThunk(
   async (address: string, thunkApi) => {
     const state = thunkApi.getState() as RootState;
     const node = selectActiveNodeApi(state);
-    const network = NETWORK === 'mainnet' ? new StacksMainnet() : new StacksTestnet();
+    const network = stacksNetwork;
     network.coreApiUrl = node.url;
     const stackingClient = new StackingClient(address, network as any);
     const [error, resp] = await safeAwait(stackingClient.getStatus());

--- a/app/utils/network-utils.ts
+++ b/app/utils/network-utils.ts
@@ -1,0 +1,13 @@
+export function isTestnet() {
+  return process.env.STX_NETWORK === 'testnet';
+}
+
+export function isMainnet() {
+  return process.env.STX_NETWORK === 'mainnet';
+}
+
+export function whenNetwork<T>({ mainnet, testnet }: { mainnet: T; testnet: T }): T {
+  if (isMainnet()) return mainnet;
+  if (isTestnet()) return testnet;
+  throw new Error('`NETWORK` is set to neither `mainnet` or `testnet`');
+}

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -73,7 +73,7 @@ export default {
       CONFIG: {
         NODE_ENV: process.env.NODE_ENV,
         PLAIN_HMR: process.env.PLAIN_HMR,
-        STX_NETWORK: process.env.STX_NETWORK || 'testnet',
+        STX_NETWORK: process.env.STX_NETWORK,
         DEBUG_PROD: process.env.DEBUG_PROD,
         START_HOT: process.env.START_HOT,
         PORT: process.env.PORT,
@@ -82,6 +82,10 @@ export default {
         SHA: process.env.SHA,
         PULL_REQUEST: process.env.PULL_REQUEST,
       },
+    }),
+
+    new webpack.EnvironmentPlugin({
+      STX_NETWORK: process.env.STX_NETWORK,
     }),
   ],
 };


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/488058744)<!-- Sticky Header Marker -->

I realised yesterday how all the `if network then x or y` logic is quite unsafe. If `STX_NETWORK` were mistakenly set to something other than `mainnet` or `testnet`, much of the logic would still function in the case of `if (NETWORK !== 'testnet')`.

This PR explicitly checks for a version type, provides a helper method, and throws if it's neither.