### PR TITLE
fix: change default core node url, closes #507

### DIFF
--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -23,7 +23,10 @@ export const BUY_STX_URL = 'https://coinmarketcap.com/currencies/blockstack/mark
 
 export const STATUS_PAGE_URL = 'http://status.test-blockstack.com';
 
-export const DEFAULT_STACKS_NODE_URL = 'https://stacks-node-api.blockstack.org';
+export const DEFAULT_STACKS_NODE_URL = whenNetwork<string>({
+  mainnet: 'https://stacks-node-api.mainnet.stacks.co',
+  testnet: 'https://stacks-node-api.testnet.stacks.co',
+});
 
 export const EXPLORER_URL = whenNetwork<string>({
   mainnet: 'https://explorer.stacks.co',


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/487678718)<!-- Sticky Header Marker -->

