### PR TITLE
chore(ci): add verified sha256 hashes for release assets, closes #515

### DIFF
--- a/.github/workflows/create-version.yml
+++ b/.github/workflows/create-version.yml
@@ -109,7 +109,7 @@ jobs:
 
       # When successful, this job creates a version tag, triggering `publish-version.yml`
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2.5.3
+        uses: cycjimmy/semantic-release-action@v2.5.4
         id: semantic
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
@@ -119,3 +119,14 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
+
+      - name: Create file with release notes
+        run: echo "${{ steps.semantic.outputs.new_release_notes }}" > release-notes.txt
+
+      - run: cat release-notes.txt
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-notes
+          path: release-notes.txt

--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -40,7 +40,7 @@ jobs:
 
           - os: windows-latest
             NPM_COMMAND: win
-            UPLOAD_ASSETS: release/**/*.exe
+            UPLOAD_ASSETS: release/*/*.exe
             CSC_LINK_SECRET_NAME: CODE_SIGNING_CERTIFICATE_WINDOWS
             CSC_KEY_PASSWORD_SECRET_NAME: CODE_SIGNING_PASSWORD_WINDOWS
 
@@ -56,6 +56,13 @@ jobs:
       - name: Add required Linux dependencies
         uses: ./.github/actions/linux-deps
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Import GPG key
+        id: import_gpg_key
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -124,6 +131,36 @@ jobs:
           name: stacks-wallet-${{ matrix.stx_network }}-${{ matrix.NPM_COMMAND }}
           path: ${{ matrix.UPLOAD_ASSETS }}
 
+  asset-signatures:
+    runs-on: ubuntu-latest
+    needs:
+      - debug-build
+
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          path: downloads
+
+      - name: Import GPG key
+        id: import_gpg_key
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Generate binary shasums
+        run: |
+          find downloads -type f -exec mv '{}' . \; && rm -rf downloads
+          ls | xargs -I{} shasum -a 256 {} | grep -v shasum.txt | tee -a shasum.txt
+          gpg --armor --output shasum.txt.asc --clearsign shasum.txt
+
+      - name: Upload binary shasums
+        uses: actions/upload-artifact@v2
+        with:
+          name: shasum.txt.asc
+          path: shasum.txt.asc
+
   announce-completion:
     runs-on: ubuntu-latest
 
@@ -139,7 +176,6 @@ jobs:
           header: '> [Download the latest build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Remove header if build failed
       - uses: lucasmotta/pull-request-sticky-header@1.0.0
         if: (contains(needs.*.result, 'failure')) && github.repository == 'blockstack/stacks-wallet'
         with:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -124,6 +124,36 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          path: release
+
+      - name: Move binaries to root directory
+        run: mv release/*/stacks-wallet* .
+
+      - name: Download release-notes.txt from create-version workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: create-version.yml
+          name: release-notes
+
+      - name: Import GPG key
+        id: import_gpg_key
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Prepare release notes
+        run: |
+          sed -i '1d' release-notes.txt
+          echo "\`\`\`" >> release-notes.txt
+          shasum -a 256 stacks-wallet* >> shasums.txt
+          gpg --armor --output shasums.txt.asc --clearsign shasums.txt
+          cat release-notes.txt shasums.txt.asc > release-body.txt
+          echo "\`\`\`" >> release-body.txt
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -134,6 +164,7 @@ jobs:
           release_name: Stacks Wallet v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ contains(needs.build.outputs.version, 'beta') }}
+          body_path: release-body.txt
 
   upload-release-assets:
     runs-on: ubuntu-latest
@@ -176,12 +207,14 @@ jobs:
 
   announce-release:
     runs-on: ubuntu-latest
+
     needs:
       - build
       - upload-release-assets
 
     steps:
       - name: Discord notification
+        if: github.ref == 'refs/heads/master'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/1038412890)<!-- Sticky Header Marker -->

Six months in the making, this PR is ready for review LOL

- Automates addition of the release notes & sha256 sums
- Wraps shasums in gpg armour

![image](https://user-images.githubusercontent.com/1618764/125833983-32ab9631-33ae-4427-b146-2e03a9827c26.png)

