### PR TITLE
fix: update coinmarketcap Stacks URL

### DIFF
--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -19,7 +19,7 @@ export const FULL_ENTITY_NAME = 'Hiro Systems PBC';
 
 export const WALLET_VERSION = packageJson.version;
 
-export const BUY_STX_URL = 'https://coinmarketcap.com/currencies/stacks/markets/';
+export const BUY_STX_URL = 'https://coinmarketcap.com/currencies/stacks/markets';
 
 export const STATUS_PAGE_URL = 'http://status.test-blockstack.com';
 

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -19,7 +19,7 @@ export const FULL_ENTITY_NAME = 'Hiro Systems PBC';
 
 export const WALLET_VERSION = packageJson.version;
 
-export const BUY_STX_URL = 'https://coinmarketcap.com/currencies/blockstack/markets';
+export const BUY_STX_URL = 'https://coinmarketcap.com/currencies/stacks/markets/';
 
 export const STATUS_PAGE_URL = 'http://status.test-blockstack.com';
 


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/512951791)<!-- Sticky Header Marker -->

## Description

From @jessesoslow 
> small note: i just clicked the "buy stacks" button in the wallet and the page doesn't load.  looks like coinmarketcap has changed the Stacks token listing from Blockstack to Stacks.  So the URL needs to be updated to https://coinmarketcap.com/currencies/stacks/

Updating the coinmarketcap URL to fix this.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

