### PR TITLE
chore: gh pages code coverage reports

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,46 @@
+name: GH pages
+
+on:
+  push:
+    branches:
+      - 'master'
+
+env:
+  STX_NETWORK: mainnet
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Cache node_modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            ${{ runner.os }}-yarn
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn
+
+      - name: Build prod
+        run: yarn build
+
+      - name: Run jest
+        run: rm -rf docs/coverage && yarn test --coverage
+
+      - name: Publish test coverage report
+        uses: JamesIves/github-pages-deploy-action@4.0.0
+        with:
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+!docs/coverage
 
 app/.yalc
 app/yalc.lock

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,8 @@ module.exports = {
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
   moduleDirectories: ['node_modules', 'app/node_modules'],
   setupFiles: ['./internals/scripts/CheckBuildsExist.js'],
+  coverageReporters: ['html'],
+  coverageDirectory: 'docs/coverage',
   globals: {
     api: true,
     CONFIG: true,


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/617024632)<!-- Sticky Header Marker -->

## Description

Adds a GH workflow that will generate and push up code coverage reports in the `gh-pages` branch to be displayed via GH pages. Since this is being committed to the `gh-pages` branch, it shouldn't interfere with the Semantic Versioning step or any other workflows which trigger from pushes to the `master` branch.

Once this is merged, we can turn on GH Pages in the repo settings.

Part of https://github.com/blockstackpbc/devops/issues/642

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No.


## Checklist
- [x] `npm run test` passes
- [x] Tag 1 of @person1 or @person2
