### PR TITLE
chore: adjust coverage dir and publish step

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,4 +43,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.0.0
         with:
           branch: gh-pages
-          folder: docs
+          folder: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
-!docs/coverage
 
 app/.yalc
 app/yalc.lock

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,6 @@ module.exports = {
   moduleDirectories: ['node_modules', 'app/node_modules'],
   setupFiles: ['./internals/scripts/CheckBuildsExist.js'],
   coverageReporters: ['html'],
-  coverageDirectory: 'docs/coverage',
   globals: {
     api: true,
     CONFIG: true,


### PR DESCRIPTION
> _Currently building new release, please wait for the latest_&nbsp; <img src="https://user-images.githubusercontent.com/1618764/97873036-51dfb200-1d17-11eb-89f5-0a922dc3ac92.gif" width="12" /><!-- Sticky Header Marker -->

## Description

Ideally the coverage report would show on the root page of this repo's GH pages. Currently it does not. These changes will adjust that in order to reach this outcome.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Checklist
- [x] `npm run test` passes
- [x] Tag 1 of @person1 or @person2
