### PR TITLE
fix(stacking): show dead delegation error, closes #691

### DIFF
--- a/app/components/error-label.tsx
+++ b/app/components/error-label.tsx
@@ -12,6 +12,6 @@ export const ErrorLabel: React.FC<ErrorLabelProps> = ({ children, size = 'sm', .
     <Box mr={2} position="relative" top={{ sm: '1px', md: '4px' }[size]}>
       <ExclamationMark />
     </Box>
-    <Box mr={5}>{children}</Box>
+    <Box>{children}</Box>
   </Flex>
 );

--- a/app/components/home/delegation-card.tsx
+++ b/app/components/home/delegation-card.tsx
@@ -8,59 +8,69 @@ import { truncateMiddle } from '@utils/tx-utils';
 import { toHumanReadableStx } from '@utils/unit-convert';
 import { DelegatedIcon } from '@components/icons/delegated-icon';
 import { homeActions } from '@store/home/home.reducer';
+import { ErrorLabel } from '@components/error-label';
+import { ErrorText } from '@components/error-text';
 
 export const DelegationCard: FC = () => {
+  const dispatch = useDispatch();
   const delegationStatus = useDelegationStatus();
   const hasPendingRevokeCall = useSelector(selectHasPendingRevokingDelegationCall);
-  const dispatch = useDispatch();
 
   if (!delegationStatus.delegated) return null;
 
   return (
-    <>
-      <Flex
-        flexDirection="column"
-        mt="extra-loose"
-        borderRadius="8px"
-        boxShadow="0px 1px 2px rgba(0, 0, 0, 0.04);"
-        border="1px solid #F0F0F5"
-        minHeight="180px"
-      >
-        <Box>
-          <Flex mt="loose" justifyContent="center">
-            <DelegatedIcon size="44px" />
-          </Flex>
-          <Text display="block" color="ink.600" textStyle="caption" mt="tight" textAlign="center">
-            You've delegated up to
+    <Flex
+      flexDirection="column"
+      mt="extra-loose"
+      borderRadius="8px"
+      boxShadow="0px 1px 2px rgba(0, 0, 0, 0.04);"
+      border="1px solid #F0F0F5"
+      minHeight="180px"
+    >
+      <Box>
+        <Flex mt="loose" justifyContent="center">
+          <DelegatedIcon size="44px" />
+        </Flex>
+        <Text display="block" color="ink.600" textStyle="caption" mt="tight" textAlign="center">
+          You've delegated up to
+        </Text>
+        <Flex justifyContent="center" mt="tight">
+          <Text textStyle="body.large.medium" fontSize="24px">
+            {toHumanReadableStx(delegationStatus.amountMicroStx.toString())}
           </Text>
-          <Flex justifyContent="center" mt="tight">
-            <Text textStyle="body.large.medium" fontSize="24px">
-              {toHumanReadableStx(delegationStatus.amountMicroStx.toString())}
+        </Flex>
+        <Box mr="2px">
+          <Flex flexDirection="column" alignItems="center" mt="base-tight" mb="base">
+            <Text textStyle="caption" color="ink.600">
+              Delegated to
+            </Text>
+            <Text fontSize="13px" mt="tight" color="ink">
+              {truncateMiddle(delegationStatus.delegatedTo, 6)}
             </Text>
           </Flex>
-          <Box mr="2px">
-            <Flex flexDirection="column" alignItems="center" mt="base-tight" mb="base-loose">
-              <Text textStyle="caption" color="ink.600">
-                Delegated to
-              </Text>
-              <Text fontSize="13px" mt="tight" color="ink">
-                {truncateMiddle(delegationStatus.delegatedTo, 6)}
-              </Text>
-            </Flex>
-          </Box>
         </Box>
-        <Box borderTop="1px solid #F0F0F2" py="extra-tight" px="extra-tight">
-          <Button
-            variant="unstyled"
-            textStyle="body.small"
-            style={{ color: '#747478' }}
-            isDisabled={hasPendingRevokeCall}
-            onClick={() => dispatch(homeActions.openRevokeDelegationModal())}
-          >
-            {hasPendingRevokeCall ? 'Currently revoking STX' : 'Revoke delegation'}
-          </Button>
-        </Box>
-      </Flex>
-    </>
+      </Box>
+      {delegationStatus.deadDelegation && (
+        <Flex flexDirection="column" alignItems="center" mb="base-loose">
+          <ErrorLabel mt="1px" maxWidth="300px">
+            <ErrorText>
+              Your delegation has expired. Your pool is no longer able to stack on your behalf.
+              Revoke your delegation and reinitiate if you wish to continue Stacking.
+            </ErrorText>
+          </ErrorLabel>
+        </Flex>
+      )}
+      <Box borderTop="1px solid #F0F0F2" py="extra-tight" px="extra-tight">
+        <Button
+          variant="unstyled"
+          textStyle="body.small"
+          style={{ color: '#747478' }}
+          isDisabled={hasPendingRevokeCall}
+          onClick={() => dispatch(homeActions.openRevokeDelegationModal())}
+        >
+          {hasPendingRevokeCall ? 'Currently revoking STX' : 'Revoke delegation'}
+        </Button>
+      </Box>
+    </Flex>
   );
 };

--- a/app/hooks/use-delegation-status.ts
+++ b/app/hooks/use-delegation-status.ts
@@ -3,17 +3,20 @@ import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import { mutate } from 'swr';
 import BN from 'bn.js';
-import { cvToString, hexToCV, ClarityType } from '@stacks/transactions';
+import { cvToString, hexToCV, ClarityType, cvToJSON } from '@stacks/transactions';
 
 import { selectAddress } from '@store/keys';
 import { RootState } from '@store/index';
 import { selectPoxInfo } from '@store/stacking';
 
 import { useFetchDelegationStatus } from './use-fetch-delegation-status';
+import { selectCoreNodeInfo } from '../store/stacking/stacking.reducer';
 
 interface DelegatedTrueStatus {
   delegated: true;
   amountMicroStx: BigNumber;
+  untilBurnHeight: BigNumber;
+  deadDelegation: boolean;
   update(): Promise<void>;
   delegatedTo: string;
 }
@@ -26,8 +29,9 @@ interface DelegatedFalseStatus {
 type DelegatedStatus = DelegatedTrueStatus | DelegatedFalseStatus;
 
 export function useDelegationStatus(): DelegatedStatus {
-  const { poxInfo, address } = useSelector((state: RootState) => ({
+  const { poxInfo, coreInfo, address } = useSelector((state: RootState) => ({
     poxInfo: selectPoxInfo(state),
+    coreInfo: selectCoreNodeInfo(state),
     address: selectAddress(state),
   }));
 
@@ -42,13 +46,24 @@ export function useDelegationStatus(): DelegatedStatus {
   const resp = hexToCV(delegationStatus.data);
   if (resp.type === ClarityType.OptionalSome && resp.value.type === ClarityType.Tuple) {
     const data = resp.value.data;
+
     const amountMicroStx = BN.isBN((data['amount-ustx'] as any).value)
       ? new BigNumber((data['amount-ustx'] as any).value.toString())
       : new BigNumber(0);
 
+    const untilBurnHeight =
+      data['until-burn-ht'].type === ClarityType.OptionalSome
+        ? cvToJSON(data['until-burn-ht']).value.value
+        : null;
+
+    const deadDelegation =
+      untilBurnHeight && coreInfo ? coreInfo.burn_block_height > untilBurnHeight : false;
+
     return {
       delegated: true,
       amountMicroStx,
+      untilBurnHeight,
+      deadDelegation,
       delegatedTo: cvToString(data['delegated-to']),
       update,
     };


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/679023477)<!-- Sticky Header Marker -->

This PR adds a warning when a user's delegation `until-burn-ht` argument is less than the current burn height. Without this warning, users are led to believe they have an active delegation (which technically they do), but one that prohibits any further stacking on their behalf.

Closes #691


![image](https://user-images.githubusercontent.com/1618764/111467213-78314780-8724-11eb-85a5-2c2cef91cde7.png)
