### PR TITLE
fix: available balance calculation

### DIFF
--- a/app/hooks/use-balance.ts
+++ b/app/hooks/use-balance.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import { selectAddress } from '@store/keys';
 import { sumTxsTotalSpentByAddress } from '@utils/tx-utils';
-import { selectAvailableBalance } from '@store/address';
+import { selectAvailableBalance, selectLockedBalance, selectTotalBalance } from '@store/address';
 import { stxBalanceValidator } from '@utils/validators/stx-balance-validator';
 import { useMempool } from './use-mempool';
 
@@ -12,6 +12,8 @@ export function useBalance() {
   const { outboundMempoolTxs } = useMempool();
   const address = useSelector(selectAddress);
   const availableBalanceValue = useSelector(selectAvailableBalance);
+  const totalBalanceValue = useSelector(selectTotalBalance);
+  const lockedBalanceValue = useSelector(selectLockedBalance);
 
   const sumTotal = useMemo(() => sumTxsTotalSpentByAddress(outboundMempoolTxs, address || ''), [
     outboundMempoolTxs,
@@ -27,8 +29,11 @@ export function useBalance() {
   const availableBalanceValidator = useCallback(() => stxBalanceValidator(availableBalance), [
     availableBalance,
   ]);
+
   return {
     availableBalance,
     availableBalanceValidator,
+    totalBalance: totalBalanceValue,
+    lockedBalance: lockedBalanceValue,
   };
 }

--- a/app/pages/home/home.tsx
+++ b/app/pages/home/home.tsx
@@ -7,7 +7,6 @@ import { openTxInExplorer } from '@utils/external-links';
 import { RootState } from '@store/index';
 import { selectAddress } from '@store/keys';
 import { selectActiveNodeApi } from '@store/stacks-node';
-import { selectAddressBalance, selectAvailableBalance } from '@store/address';
 import { selectRevokeDelegationModalOpen } from '@store/home/home.reducer';
 import { selectTransactionsLoading, selectTransactionListFetchError } from '@store/transaction';
 import { selectLoadingStacking, selectNextCycleInfo, selectStackerInfo } from '@store/stacking';
@@ -52,8 +51,6 @@ export const Home: FC = () => {
 
   const {
     address,
-    balance,
-    spendableBalance,
     loadingTxs,
     txModalOpen,
     txListFetchError,
@@ -64,8 +61,6 @@ export const Home: FC = () => {
     stackingCardState,
   } = useSelector((state: RootState) => ({
     address: selectAddress(state),
-    spendableBalance: selectAvailableBalance(state),
-    balance: selectAddressBalance(state),
     txModalOpen: selectTxModalOpen(state),
     revokeDelegationModalOpen: selectRevokeDelegationModalOpen(state),
     receiveModalOpen: selectReceiveModalOpen(state),
@@ -116,8 +111,6 @@ export const Home: FC = () => {
   const balanceCard = (
     <BalanceCard
       address={address}
-      lockedStx={balance?.locked}
-      balance={availableBalance.toString() || null}
       onSelectSend={() => dispatch(homeActions.openTxModal())}
       onSelectReceive={() => dispatch(homeActions.openReceiveModal())}
       onRequestTestnetStx={async ({ stacking }) => api.getFaucetStx(address, stacking)}
@@ -144,7 +137,7 @@ export const Home: FC = () => {
   return (
     <>
       {receiveModalOpen && <ReceiveStxModal />}
-      {txModalOpen && <TransactionModal balance={spendableBalance || '0'} address={address} />}
+      {txModalOpen && <TransactionModal balance={availableBalance.toString()} address={address} />}
       {revokeDelegationModalOpen && <RevokeDelegationModal />}
       <HomeLayout
         transactionList={transactionList}

--- a/app/store/address/address.reducer.ts
+++ b/app/store/address/address.reducer.ts
@@ -35,3 +35,13 @@ export const selectAvailableBalance = createSelector(selectAddressState, address
   if (address.details === null) return null;
   return new BigNumber(address.details.balance).minus(address.details.locked).toString();
 });
+
+export const selectTotalBalance = createSelector(selectAddressState, address => {
+  if (address.details === null) return null;
+  return new BigNumber(address.details.balance);
+});
+
+export const selectLockedBalance = createSelector(selectAddressState, address => {
+  if (address.details === null) return null;
+  return new BigNumber(address.details.locked);
+});


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/719508754)<!-- Sticky Header Marker -->

Bug was caused by locked amount being subtracted twice. Had missed this old in-component code that was re-calculating the locked/total.

Refactored to only use values via hook.