### PR TITLE
fix: display where wallet's data is

### DIFF
--- a/app/main/register-store-handlers.ts
+++ b/app/main/register-store-handlers.ts
@@ -1,11 +1,14 @@
 import Store from 'electron-store';
 import { ipcMain } from 'electron';
+import path from 'path';
 
 export function registerIpcStoreHandlers(userDataPath: string) {
   const store = new Store({
     clearInvalidConfig: true,
     cwd: userDataPath,
   });
+
+  ipcMain.on('get-user-data-path', e => (e.returnValue = path.join(userDataPath, 'config.json')));
 
   ipcMain.handle('store-set', (_e, { key, value }: any) => store.set(key, value));
 

--- a/app/pages/settings/settings.tsx
+++ b/app/pages/settings/settings.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Button } from '@blockstack/ui';
+import { Text, Button } from '@blockstack/ui';
 
 import routes from '@constants/routes.json';
 import { useBackButton } from '@hooks/use-back-url';
-import { selectWalletType } from '@store/keys/keys.reducer';
 import { ResetWalletModal } from '@modals/reset-wallet/reset-wallet-modal';
 
 import { RootState } from '@store/index';
@@ -22,18 +21,18 @@ import { NodeSelectItem } from '@components/settings/node-select-item';
 import { SettingSection } from '@components/settings/settings-section';
 
 import { SettingsLayout, SettingDescription } from './settings-layout';
+import { useWalletType } from '@hooks/use-wallet-type';
 
 export const Settings = () => {
   const dispatch = useDispatch();
-  const { nodes, selectedNodeApi, walletType } = useSelector((state: RootState) => ({
+  const { nodes, selectedNodeApi } = useSelector((state: RootState) => ({
     nodes: selectStacksNodeApis(state),
     selectedNodeApi: selectActiveNodeApi(state),
-    walletType: selectWalletType(state),
   }));
   const [resetModalOpen, setResetModalOpen] = useState(false);
   const [nodeModalOpen, setNodeModalOpen] = useState(false);
   const [operation, setOperation] = useState<'create' | 'update'>('create');
-
+  const { whenWallet } = useWalletType();
   useBackButton(routes.HOME);
 
   return (
@@ -65,10 +64,15 @@ export const Settings = () => {
       </SettingSection>
       <SettingSection title="Reset wallet">
         <SettingDescription>
-          When you reset your wallet,
-          {walletType === 'software' &&
-            ' you will need to sign back in with your 24-word Secret Key.'}
-          {walletType === 'ledger' && ' you will need to reauthenticate with your Ledger device'}
+          When you reset your wallet, you will need to
+          {whenWallet({
+            software: ' sign back in with your 24-word Secret Key.',
+            ledger: ' reauthenticate with your Ledger device',
+          })}
+          <br />
+          <Text mt="base-tight" display="block" color="ink.600" textStyle="caption">
+            Your wallet data can be found in: <code>{main.getUserDataPath()}</code>
+          </Text>
         </SettingDescription>
         <ResetWalletModal isOpen={resetModalOpen} onClose={() => setResetModalOpen(false)} />
 

--- a/app/preload.ts
+++ b/app/preload.ts
@@ -90,9 +90,9 @@ const walletApi = {
 
   contextMenu: (menuItems: any) => ipcRenderer.send('context-menu-open', { menuItems }),
 
-  installPath: () => ipcRenderer.sendSync('installPath'),
-
   closeWallet: () => ipcRenderer.send('closeWallet'),
+
+  getUserDataPath: () => ipcRenderer.sendSync('get-user-data-path'),
 
   ledger: {
     createListener: () => ipcRenderer.send('create-ledger-listener'),


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/763943906)<!-- Sticky Header Marker -->

Open to suggestions as to better ways to display this better, but the wallet should really show where it's data is.

![image](https://user-images.githubusercontent.com/1618764/114193163-89016180-994e-11eb-9575-26a75a65205b.png)
