### PR TITLE
fix: send stx modal not closing

### DIFF
--- a/app/modals/send-stx/send-stx-modal.tsx
+++ b/app/modals/send-stx/send-stx-modal.tsx
@@ -180,7 +180,7 @@ export const TransactionModal: FC<TxModalProps> = ({ address, isOpen }) => {
   const sendStx = (tx: StacksTransaction) => {
     broadcastTx({
       async onSuccess(txId: string) {
-        await watchForNewTxToAppear({ txId, nodeUrl: stacksApi.baseUrl });
+        await safeAwait(watchForNewTxToAppear({ txId, nodeUrl: stacksApi.baseUrl }));
         await safeAwait(queryClient.refetchQueries(['mempool']));
         closeModal();
         resetAll();


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/812833558)<!-- Sticky Header Marker -->

@yknl I was unable to replicate [the issue you mentioned on Discord](https://discord.com/channels/621759717756370964/745197302255321108/839258638097973278), but I have a feeling it may have been related to an unhandled error.

This change wraps the suspected-failing call in `safeAwait`, a method that catches any error, allowing the promise to proceed and, subsequently, close the modal.