### PR TITLE
fix(theme): handle theme change during closed window

### DIFF
--- a/app/main/register-theme-mode-handlers.ts
+++ b/app/main/register-theme-mode-handlers.ts
@@ -8,6 +8,12 @@ export function registerThemeModeHandlers(webContents: WebContents) {
     });
   });
 
+  webContents.on('destroyed', () => {
+    nativeTheme.removeAllListeners();
+    ipcMain.removeHandler('theme:toggle-mode');
+    ipcMain.removeHandler('theme:set-system-mode');
+  });
+
   ipcMain.on(
     'theme:get-current',
     e => (e.returnValue = nativeTheme.shouldUseDarkColors ? 'dark' : 'light')
@@ -20,14 +26,6 @@ export function registerThemeModeHandlers(webContents: WebContents) {
       nativeTheme.themeSource = 'dark';
     }
     return nativeTheme.shouldUseDarkColors;
-  });
-
-  ipcMain.handle('theme:set-dark-mode', () => {
-    nativeTheme.themeSource = 'dark';
-  });
-
-  ipcMain.handle('theme:set-light-mode', () => {
-    nativeTheme.themeSource = 'light';
   });
 
   ipcMain.handle('theme:set-system-mode', () => {

--- a/app/preload.ts
+++ b/app/preload.ts
@@ -100,12 +100,6 @@ const walletApi = {
     toggleMode() {
       return ipcRenderer.invoke('theme:toggle-mode');
     },
-    setDarkMode() {
-      return ipcRenderer.invoke('theme:set-dark-mode');
-    },
-    setLightMode() {
-      return ipcRenderer.invoke('theme:set-light-mode');
-    },
     setSystemMode() {
       return ipcRenderer.invoke('theme:set-system-mode');
     },


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/816807633)<!-- Sticky Header Marker -->

Fixes bug on macoS where exception is thrown when system theme changes, and the window is closed.

Solution is to add/remove handlers based on window creation.