### PR TITLE
fix: add memo warning to prevent user error, closes #571

### DIFF
--- a/app/modals/send-stx/send-stx-modal.tsx
+++ b/app/modals/send-stx/send-stx-modal.tsx
@@ -96,6 +96,7 @@ export const TransactionModal: FC<TxModalProps> = ({ address, isOpen }) => {
       recipient: '',
       amount: '',
       memo: '',
+      noMemoRequired: false,
     },
     validationSchema: yup.object().shape({
       recipient: yup
@@ -133,11 +134,25 @@ export const TransactionModal: FC<TxModalProps> = ({ address, isOpen }) => {
           }
         )
         .required(),
-      memo: yup
-        .string()
-        .test('test-max-memo-length', 'Transaction memo cannot exceed 34 bytes', (value = '') =>
-          value === null ? false : !exceedsMaxLengthBytes(value, MEMO_MAX_LENGTH_BYTES)
-        ),
+      memo: yup.string().when('noMemoRequired', {
+        is: false,
+        then: yup
+          .string()
+          .required()
+          .test({
+            name: 'memo-required',
+            message: 'Memo is required. If you do not need to set a memo, confirm this below.',
+            test(value: unknown) {
+              if (typeof value !== 'string') return false;
+              if (value.trim() === '') return false;
+              return true;
+            },
+          })
+          .test('test-max-memo-length', 'Transaction memo cannot exceed 34 bytes', (value = '') =>
+            value === null ? false : !exceedsMaxLengthBytes(value, MEMO_MAX_LENGTH_BYTES)
+          ),
+      }),
+      noMemoRequired: yup.boolean().required(),
     }),
     onSubmit: async () => {
       setLoading(true);
@@ -228,7 +243,6 @@ export const TransactionModal: FC<TxModalProps> = ({ address, isOpen }) => {
           onSendEntireBalance={updateAmountFieldToMaxBalance}
           feeEstimateError={feeEstimateError}
         />
-
         <TxModalFooter>
           <TxModalButton mode="tertiary" onClick={closeModal}>
             Cancel

--- a/app/modals/send-stx/steps/transaction-form.tsx
+++ b/app/modals/send-stx/steps/transaction-form.tsx
@@ -1,15 +1,14 @@
 import React, { FC } from 'react';
-import { Flex, Text, Input, Box, Button } from '@stacks/ui';
+import { Flex, Text, Input, Box, Button, color } from '@stacks/ui';
 import { ErrorLabel } from '@components/error-label';
 import { ErrorText } from '@components/error-text';
 import { FormikProps } from 'formik';
 import { capitalize } from '@utils/capitalize';
 import { toHumanReadableStx } from '@utils/unit-convert';
 import { HomeSelectors } from 'app/tests/features/home.selectors';
-
 interface TxModalFormProps {
   balance: string;
-  form: FormikProps<{ recipient: string; amount: string; memo: string }>;
+  form: FormikProps<{ recipient: string; amount: string; memo: string; noMemoRequired: boolean }>;
   isCalculatingMaxSpend: boolean;
   onSendEntireBalance(): void;
   feeEstimateError: string | null;
@@ -82,21 +81,45 @@ export const TxModalForm: FC<TxModalFormProps> = props => {
             Send max
           </Button>
         </Box>
+
         <Text
           textStyle="body.small.medium"
           mt="base-loose"
+          mr="extra-tight"
           as="label"
           {...{ htmlFor: 'stxAmount' }}
         >
           Memo
         </Text>
+        <Text textStyle="body.small" color={color('text-caption')} mt="tight">
+          Exchanges often require a memo to credit the STX to your account.
+        </Text>
+        <Flex
+          as="label"
+          textStyle="body.small"
+          color={color('text-body')}
+          mt="base-tight"
+          alignItems="baseline"
+        >
+          <Box mr="tight" mt="1px">
+            <input
+              type="checkbox"
+              id="noMemoRequired"
+              name="noMemoRequired"
+              onChange={form.handleChange}
+              checked={form.values.noMemoRequired}
+            />
+          </Box>
+          I confirm no memo is required for this transaction
+        </Flex>
         <Input
           id="memo"
           data-test={HomeSelectors.InputSendStxFormMemo}
           name="memo"
           inputMode="numeric"
-          mt="base-tight"
+          mt="base-loose"
           placeholder="Memo"
+          isDisabled={form.values.noMemoRequired}
           onChange={form.handleChange}
           value={form.values.memo}
         />


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/871058139)<!-- Sticky Header Marker -->

I've seen many reports of this lately so thought it worth trying to work in a fix.

An explicit confirmation when **no memo is needed** seems to be the most common pattern when withdrawing/depositing memo-using currencies, STX, XLM etc. I haven't given much thought to the exact messaging, so please leave feedback.

Closes #571 

https://user-images.githubusercontent.com/1618764/118469334-e6cf5900-b705-11eb-8c7e-6bac4e84e4b1.mp4


