### PR TITLE
fix(ledger): ledger app version handling

### DIFF
--- a/app/components/tx-signing/sign-transaction-ledger.tsx
+++ b/app/components/tx-signing/sign-transaction-ledger.tsx
@@ -8,18 +8,23 @@ import { LedgerConnectStep, usePrepareLedger } from '@hooks/use-prepare-ledger';
 import { safeAwait } from '@utils/safe-await';
 import { capitalize } from '@utils/capitalize';
 
-import { SignTransactionProps } from './sign-transaction';
 import {
   StackingModalButton as Button,
   StackingModalFooter as Footer,
 } from '../../modals/components/stacking-modal-layout';
+import { SignTransactionProps } from './sign-transaction';
 
 type SignTransactionLedgerProps = SignTransactionProps;
 
 export const SignTransactionLedger = (props: SignTransactionLedgerProps) => {
   const { action, txOptions, isBroadcasting, onTransactionSigned, onClose } = props;
 
-  const { step: ledgerStep, isLocked } = usePrepareLedger();
+  const {
+    step: ledgerStep,
+    isLocked,
+    isSupportedAppVersion,
+    appVersionErrorText,
+  } = usePrepareLedger();
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const { createLedgerContractCallTx } = useCreateLedgerContractCallTx();
   const { createLedgerTokenTransferTx } = useCreateLedgerTokenTransferTx();
@@ -33,7 +38,11 @@ export const SignTransactionLedger = (props: SignTransactionLedgerProps) => {
 
   return (
     <>
-      <SignTxWithLedger step={ledgerStep} isLocked={isLocked} ledgerError={null} />
+      <SignTxWithLedger
+        step={ledgerStep}
+        isLocked={isLocked}
+        ledgerError={isSupportedAppVersion ? null : appVersionErrorText}
+      />
       <Footer>
         <Button mode="tertiary" onClick={onClose}>
           Close

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -64,6 +64,10 @@ export const STACKING_CONTRACT_CALL_FEE = 260;
 
 export const SUPPORTED_BTC_ADDRESS_FORMATS = ['p2pkh', 'p2sh'] as const;
 
+export const SUPPORTED_LEDGER_VERSION_MAJOR = 0;
+
+export const SUPPORTED_LEDGER_VERSION_MINOR = 11;
+
 export const DEFAULT_POLLING_INTERVAL = 10_000;
 
 export const features = {

--- a/app/hooks/use-fetch-account-nonce.ts
+++ b/app/hooks/use-fetch-account-nonce.ts
@@ -10,8 +10,15 @@ export function useFetchAccountNonce() {
   const api = useApi();
   const address = useSelector(selectAddress);
 
-  const nonceFetcher = useCallback(() => api.getNonce(address || ''), [api, address]);
-  const { data } = useQuery(ApiResource.Nonce, nonceFetcher);
+  const nonceFetcher = useCallback(
+    ({ queryKey }) => {
+      const [_, innerAddress] = queryKey;
+      if (!innerAddress) return;
+      return api.getNonce(innerAddress);
+    },
+    [api]
+  );
+  const { data } = useQuery([ApiResource.Nonce, address], nonceFetcher);
   if (!data) return { nonce: 0 };
   return { nonce: data.nonce };
 }

--- a/app/pages/onboarding/04-connect-ledger/connect-ledger.tsx
+++ b/app/pages/onboarding/04-connect-ledger/connect-ledger.tsx
@@ -32,7 +32,7 @@ export const ConnectLedger: React.FC = () => {
   const [ledgerLaunchVersionError, setLedgerLaunchVersionError] = useState<string | null>(null);
   useBackButton(routes.CREATE);
 
-  const { step, isLocked } = usePrepareLedger();
+  const { step, isLocked, appVersionErrorText, isSupportedAppVersion } = usePrepareLedger();
 
   const dispatch = useDispatch();
   const history = useHistory();
@@ -114,10 +114,15 @@ export const ConnectLedger: React.FC = () => {
           <ErrorText>You must approve the action that appears on your Ledger device</ErrorText>
         </ErrorLabel>
       )}
+      {!isSupportedAppVersion && (
+        <ErrorLabel mt="base-loose">
+          <ErrorText>{appVersionErrorText}</ErrorText>
+        </ErrorLabel>
+      )}
       <OnboardingButton
         mt="loose"
         onClick={handleLedger}
-        isDisabled={step < 2 || loading || isLocked}
+        isDisabled={step < 2 || loading || isLocked || !isSupportedAppVersion}
         isLoading={loading}
       >
         Continue


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/857196822)<!-- Sticky Header Marker -->

This PR introduces the hard coded version number of the latest Stacks Ledger app. By pinning this version to the next release, we can ensure no breaking changes when the newer one is released, at which time we'll amend this behaviour to support the latest version.

![image](https://user-images.githubusercontent.com/1618764/118822716-ae23b100-b8b8-11eb-8240-99e16dc4b958.png)
