### PR TITLE
fix(stx-form): validation error throwing inaccurately, closes #815

### DIFF
--- a/app/modals/send-stx/steps/transaction-form.tsx
+++ b/app/modals/send-stx/steps/transaction-form.tsx
@@ -69,6 +69,7 @@ export const TxModalForm: FC<TxModalFormProps> = props => {
           )}
           <Button
             mode="tertiary"
+            type="button"
             size="sm"
             height="28px"
             right="12px"


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/877712347)<!-- Sticky Header Marker -->

Fixes form validation bug reported by @Eshwari007 🎉  

Closes #815.

I don't fully recall why I added this send max handling behaviour. Nonetheless, it's the cause of randomly throwing validation error so safe to remove. 