### PR TITLE
fix(stacking): round progress percentage to two decimals

### DIFF
--- a/app/components/home/delegation-card.tsx
+++ b/app/components/home/delegation-card.tsx
@@ -89,9 +89,7 @@ export const DelegationCard: FC = () => {
               </Row>
               <Row>
                 <Label>Progress</Label>
-                <Value>
-                  {stackerInfo?.stackingPercentage ? stackerInfo?.stackingPercentage : '0'}%
-                </Value>
+                <Value>{stackerInfo?.stackingPercentage ?? 0}%</Value>
               </Row>
             </Section>
 

--- a/app/store/stacking/stacking.reducer.ts
+++ b/app/store/stacking/stacking.reducer.ts
@@ -217,8 +217,10 @@ export const selectStackerInfo = createSelector(
     const blocksUntilStackingCycleBegins =
       addressBalances.lock_height - state.coreNodeInfo.burn_block_height;
 
-    const stackingPercentage =
+    const stackingPercentageLong =
       ((cycleLengthInBlocks - blocksUntilUnlocked) / cycleLengthInBlocks) * 100;
+
+    const stackingPercentage = Number(stackingPercentageLong.toFixed(2));
 
     let status: StackingStatus = StackingStatus.NotStacking;
     if (isPreStackingPeriodStart) status = StackingStatus.StackedPreCycle;


### PR DESCRIPTION
## Description

Closes #837

- Before: `Progress: 1.608495354103225%`
- After: `Progress: 1.60%`

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other (Enhancement)

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated

@kyranjamie @markmhx