### PR TITLE
fix(home): use cached txs as fallback when endpoint fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/blockstack/stacks-wallet/Build)
 [![coverage](https://raw.githubusercontent.com/blockstack/stacks-wallet/gh-pages/badge.svg)](https://blockstack.github.io/stacks-wallet/)
 
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/blockstack/stacks-wallet)
+
+
 ![Stacks Wallet Hero](/resources/readme.png)
 
 Implementation of the Stacks 2.0 wallet for Desktop

--- a/app/components/home/transaction-list/transaction-list.tsx
+++ b/app/components/home/transaction-list/transaction-list.tsx
@@ -17,7 +17,7 @@ export const TransactionList: FC<TransactionListProps> = props => {
   const { node, txCount, loading, children, error } = props;
 
   if (loading) return <TransactionListLoading />;
-  if (error) return <TransactionListError node={node} error={error} />;
+  if (error && txCount === 0) return <TransactionListError node={node} error={error} />;
   if (txCount === 0) return <TransactionListEmpty />;
 
   return (

--- a/app/store/transaction/transaction.reducer.ts
+++ b/app/store/transaction/transaction.reducer.ts
@@ -54,11 +54,8 @@ const selectors = transactionAdapter.getSelectors(selectTxState);
 
 export const selectTransactionList = (state: RootState) => selectors.selectAll(state);
 
-export const selectMostRecentlyTxError = createSelector(
-  selectTxState,
-  state => state.mostRecentBroadcastError
-);
 export const selectTransactionsLoading = createSelector(selectTxState, state => state.loading);
+
 export const selectTransactionListFetchError = createSelector(
   selectTxState,
   state => state.fetchTxError


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/1029533728)<!-- Sticky Header Marker -->

This PR adds a conditions then ensures the "cannot load tx list" state is only shown when there are no cached txs.

Currently, if the endpoint fails intermittently, the wallet will toggle between the list and the error state (bad ux)