### PR TITLE
fix(home): only show 'tx_status' pending mempool txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/blockstack/stacks-wallet/Build)
 [![coverage](https://raw.githubusercontent.com/blockstack/stacks-wallet/gh-pages/badge.svg)](https://blockstack.github.io/stacks-wallet/)
 
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/blockstack/stacks-wallet)
+
+
 ![Stacks Wallet Hero](/resources/readme.png)
 
 Implementation of the Stacks 2.0 wallet for Desktop

--- a/app/hooks/use-mempool.ts
+++ b/app/hooks/use-mempool.ts
@@ -35,5 +35,7 @@ export function useMempool(): UseMempool {
     .filter(tx => tx.sender_address === address)
     .filter(tx => tx.nonce >= nonce);
 
-  return { mempoolTxs, outboundMempoolTxs, refetch };
+  const pendingMempoolTxs = mempoolTxs.filter(tx => tx.tx_status === 'pending');
+
+  return { mempoolTxs: pendingMempoolTxs, outboundMempoolTxs, refetch };
 }


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/1030303976)<!-- Sticky Header Marker -->

User reported issue with hanging pending txs. These were mempool txs with status `dropped_stale_garbage_collect`.

This PR filters them, as only `pending` txs should be shown.