### PR TITLE
refactor: change to hiro wallet branding

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -131,7 +131,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ needs.build.outputs.version }}
-          release_name: Stacks Wallet v${{ needs.build.outputs.version }}
+          release_name: Hiro Wallet v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ contains(needs.build.outputs.version, 'beta') }}
 
@@ -187,4 +187,4 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: |
-            🔔 New Stacks Wallet released: [Download `v${{ needs.build.outputs.version }}` here](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.build.outputs.version }})
+            🔔 New Hiro Wallet released: [Download `v${{ needs.build.outputs.version }}` here](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.build.outputs.version }})

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Stacks Wallet for Desktop
+# Hiro Wallet for Desktop
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/blockstack/stacks-wallet/Build)
 [![coverage](https://raw.githubusercontent.com/blockstack/stacks-wallet/gh-pages/badge.svg)](https://blockstack.github.io/stacks-wallet/)
 
 [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/blockstack/stacks-wallet)
 
-
-![Stacks Wallet Hero](/resources/readme.png)
+![Hiro Wallet Hero](/resources/readme.png)
 
 Implementation of the Stacks 2.0 wallet for Desktop
 

--- a/app/components/version-info.tsx
+++ b/app/components/version-info.tsx
@@ -23,7 +23,7 @@ const issueBody = `
 
 -->
 
-Bug found testing Stacks Wallet build ${String(shaShort)}, ${String(version)}.
+Bug found testing Hiro Wallet build ${String(shaShort)}, ${String(version)}.
 
 `;
 

--- a/app/hooks/use-prepare-ledger.ts
+++ b/app/hooks/use-prepare-ledger.ts
@@ -54,10 +54,10 @@ export function usePrepareLedger() {
     return `
       Make sure to upgrade your Stacks app to the latest version in Ledger Live. ${
         isNewerReleaseAvailable
-          ? 'You should also upgrade your Stacks Wallet to the latest version.'
+          ? 'You should also upgrade your Hiro Wallet to the latest version.'
           : ''
       }
-      This version of the Stacks Wallet works with ${EARLIEST_SUPPORTED_LEDGER_VERSION} onwards.
+      This version of the Hiro Wallet works with ${EARLIEST_SUPPORTED_LEDGER_VERSION} onwards.
       Detected version ${String(appVersion?.major)}.${String(appVersion?.minor)}.${String(
       appVersion?.patch
     )}

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -85,7 +85,7 @@ const createWindow = async () => {
     frame: process.platform !== 'darwin',
     titleBarStyle: process.platform === 'darwin' ? 'hidden' : 'default',
     icon: iconPath,
-    title: `Stacks Wallet` + (process.env.STX_NETWORK === 'testnet' ? ' Testnet' : ''),
+    title: `Hiro Wallet` + (process.env.STX_NETWORK === 'testnet' ? ' Testnet' : ''),
     webPreferences: {
       disableBlinkFeatures: 'Auxclick',
       spellcheck: false,

--- a/app/main/macos-touchbar-menu.ts
+++ b/app/main/macos-touchbar-menu.ts
@@ -3,7 +3,7 @@ import { BrowserWindow, TouchBar } from 'electron';
 const { TouchBarLabel } = TouchBar;
 
 const stxTouchBarButton = new TouchBarLabel({
-  label: 'Stacks Wallet',
+  label: 'Hiro Wallet',
 });
 
 const touchBar = new TouchBar({

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -68,17 +68,17 @@ export default class MenuBuilder {
 
   buildDarwinTemplate() {
     const subMenuAbout: DarwinMenuItemConstructorOptions = {
-      label: 'Stacks Wallet',
+      label: 'Hiro Wallet',
       submenu: [
         {
-          label: 'About Stacks Wallet',
+          label: 'About Hiro Wallet',
           selector: 'orderFrontStandardAboutPanel:',
         },
         { type: 'separator' },
         { label: 'Services', submenu: [] },
         { type: 'separator' },
         {
-          label: 'Hide Stacks Wallet',
+          label: 'Hide Hiro Wallet',
           accelerator: 'Command+H',
           selector: 'hide:',
         },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stacks-wallet-inner-package",
-  "description": "Stacks Wallet v4 — Participate in Stacking to earn bitcoin rewards",
+  "description": "Hiro Wallet v4 — Participate in Stacking to earn bitcoin rewards",
   "main": "./main.prod.js",
   "author": {
     "email": "info@blockstack.com",

--- a/app/pages/onboarding/00-terms/terms.tsx
+++ b/app/pages/onboarding/00-terms/terms.tsx
@@ -22,10 +22,10 @@ export const Terms: React.FC = () => {
         Terms of Service
       </OnboardingTitle>
       <OnboardingText mb="extra-loose">
-        You must first accept the terms of service before using the Stacks Wallet
+        You must first accept the terms of service before using the Hiro Wallet
       </OnboardingText>
       <Box textStyle="body.small" mx="base">
-        These terms of use (“<strong>Terms</strong>”) govern your use of the Stacks Wallet software
+        These terms of use (“<strong>Terms</strong>”) govern your use of the Hiro Wallet software
         (the “<strong>Software</strong>”) made available to you by {FULL_ENTITY_NAME} (“
         <strong>{ENTITY_NAME}</strong>”). By clicking “I Accept,” downloading, installing,
         accessing, or using the Software, you agree to be bound by the following terms and

--- a/app/pages/onboarding/01-welcome/welcome.tsx
+++ b/app/pages/onboarding/01-welcome/welcome.tsx
@@ -18,7 +18,7 @@ export const Welcome: React.FC = () => {
 
   return (
     <Onboarding>
-      <OnboardingTitle>Stacks Wallet</OnboardingTitle>
+      <OnboardingTitle>Hiro Wallet</OnboardingTitle>
       <OnboardingText>
         Manage your STX holdings, and earn Bitcoin by participating in Stacking
       </OnboardingText>

--- a/app/pages/onboarding/03-restore-wallet/restore-wallet.tsx
+++ b/app/pages/onboarding/03-restore-wallet/restore-wallet.tsx
@@ -50,7 +50,7 @@ export const RestoreWallet: React.FC = () => {
     const mnemonicLength = parsedMnemonic.split(' ').length;
 
     if (mnemonicLength !== 12 && mnemonicLength !== 24) {
-      setError('The Stacks Wallet can be used with only 12 and 24-word Secret Keys');
+      setError('The Hiro Wallet can be used with only 12 and 24-word Secret Keys');
       return;
     }
 

--- a/app/pages/onboarding/05-secret-key/secret-key.tsx
+++ b/app/pages/onboarding/05-secret-key/secret-key.tsx
@@ -33,8 +33,8 @@ export const SecretKey: React.FC = () => {
     <Onboarding>
       <OnboardingTitle>Your Secret Key</OnboardingTitle>
       <OnboardingText>
-        Here's your Secret Key: 24 words that give you access to your Stacks Wallet. If you lose
-        your Secret Key, you'll be unable to access your STX tokens. No one can reset it for you.
+        Here's your Secret Key: 24 words that give you access to your Hiro Wallet. If you lose your
+        Secret Key, you'll be unable to access your STX tokens. No one can reset it for you.
       </OnboardingText>
       <Card title="Your Secret Key" mt="extra-loose">
         <Text textStyle="body.small" mt="loose" mx="loose" lineHeight="20px" display="block">

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -69,7 +69,7 @@ const baseConfig = {
 
 const networkConfigs = {
   testnet: {
-    productName: 'Stacks Wallet Testnet',
+    productName: 'Hiro Wallet Testnet',
     appId: 'so.hiro.StacksWalletTestnet',
     artifactName: 'stacks-wallet.testnet.${ext}',
     mac: {
@@ -84,11 +84,11 @@ const networkConfigs = {
     // macos `Application Support` dir name
     extraMetadata: {
       name: 'stacks-wallet-testnet',
-      productName: 'Stacks Wallet Testnet',
+      productName: 'Hiro Wallet Testnet',
     },
   },
   mainnet: {
-    productName: 'Stacks Wallet',
+    productName: 'Hiro Wallet',
     appId: 'so.hiro.StacksWallet',
     icon: 'icon-512x512.png',
     artifactName: 'stacks-wallet.mainnet.${ext}',
@@ -103,7 +103,7 @@ const networkConfigs = {
     },
     extraMetadata: {
       name: 'stacks-wallet',
-      productName: 'Stacks Wallet',
+      productName: 'Hiro Wallet',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stacks-wallet",
   "version": "4.4.0",
-  "description": "Stacks Wallet 2.0 — Stacking",
+  "description": "Hiro Wallet 2.0 — Stacking",
   "prettier": "@stacks/prettier-config",
   "homepage": "https://hiro.so/wallet",
   "author": {


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/1046077023)<!-- Sticky Header Marker -->

## Description

This PR updates the wallet name to `Hiro Wallet`.


