### PR TITLE
feat: use a get to check status

### DIFF
--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -118,7 +118,7 @@ export class Api {
   }
 
   async getNodeStatus() {
-    return axios.post(urljoin(this.baseUrl, `/extended/v1/status`));
+    return axios.get(urljoin(this.baseUrl, `/extended/v1/status`));
   }
 
   async getCoreDetails() {


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/1218194054)<!-- Sticky Header Marker -->

I have no idea why this was a post. Did the API once return from POSTs?