### PR TITLE
Remove 3rd party notification from link to Explorer #937

### DIFF
--- a/app/components/home/balance-card.tsx
+++ b/app/components/home/balance-card.tsx
@@ -7,7 +7,7 @@ import { toHumanReadableStx } from '@utils/unit-convert';
 import { safeAwait } from '@utils/safe-await';
 import { delay } from '@utils/delay';
 
-import { ExternalLink } from '@components/external-link';
+import { InternalLink } from '@components/internal-link';
 import { makeExplorerAddressLink } from '@utils/external-links';
 import { isTestnet } from '@utils/network-utils';
 import { useBalance } from '@hooks/use-balance';
@@ -46,9 +46,9 @@ export const BalanceCard: FC<BalanceCardProps> = props => {
         </Text>
 
         {address !== null && (
-          <ExternalLink href={makeExplorerAddressLink(address)} textStyle="caption" ml="tight">
+          <InternalLink href={makeExplorerAddressLink(address)} textStyle="caption" ml="tight">
             View on Explorer
-          </ExternalLink>
+          </InternalLink>
         )}
       </Flex>
       <Title fontSize="40px" lineHeight="56px">

--- a/app/components/internal-link.tsx
+++ b/app/components/internal-link.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+import { Box, Text, BoxProps, color } from '@stacks/ui';
+import { openExternalLink } from '@utils/external-links';
+
+interface InternalLinkProps extends BoxProps {
+  href: string;
+}
+
+export const InternalLink: FC<InternalLinkProps> = ({ href, children, ...props }) => {
+  const openUrl = () => openExternalLink(href);
+  return (
+    <Text
+      onClick={openUrl}
+      as="button"
+      type="button"
+      cursor="pointer"
+      display="block"
+      outline={0}
+      color={color('brand')}
+      _hover={{ textDecoration: 'underline' }}
+      _focus={{ textDecoration: 'underline' }}
+      {...props}
+    >
+      {children}
+      <Box display="inline-block" ml="extra-tight" mb="1px">
+        ↗
+      </Box>
+    </Text>
+  );
+};


### PR DESCRIPTION
## Description

The 3rd party link warning (from `LegalDisclaimerTooltip`) was showing up for the 'View on Explorer' link in `BalanceCard` component. This warning should not be displayed for links owned by Stacks. The solution was to create a new component, `InternalLink` that is _not_ wrapped in `LegalDisclaimerTooltip` component. This new component has the exact same API as `ExternalLink`.

Example:
```
<InternalLink href={link} textStyle="caption" ml="tight">
  Link Text
</InternalLink>
```

For details refer to issue #937

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
I do not believe so, but I am not familiar enough with the project to determine if doc updates are a requirement.

## Testing information
I did test this manually, but have not provided a unit test. All unit tests still pass.

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
