### PR TITLE
ci: update release flow branches

### DIFF
--- a/.github/workflows/create-version.yml
+++ b/.github/workflows/create-version.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'beta'
+      - 'dev'
     tags-ignore:
       - '**'
     paths-ignore:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -112,6 +112,7 @@ jobs:
 
     outputs:
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+      new_version: ${{ steps.extract_version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v2
@@ -204,7 +205,7 @@ jobs:
         with:
           upload_url: ${{ needs.create-release.outputs.release_upload_url }}
           asset_path: release/stacks-wallet-${{ matrix.stx_network }}-${{ matrix.os }}/stacks-wallet.${{ matrix.stx_network }}.${{ matrix.ext }}
-          asset_name: stacks-wallet.${{ matrix.stx_network }}.v${{ needs.build.outputs.version }}.${{ matrix.ext }}
+          asset_name: stacks-wallet.${{ matrix.stx_network }}.v${{ needs.create-release.outputs.new_version }}.${{ matrix.ext }}
           asset_content_type: application/octet-stream
 
   announce-release:
@@ -221,4 +222,4 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: |
-            🔔 New Hiro Wallet released: [Download `v${{ needs.build.outputs.version }}` here](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.build.outputs.version }})
+            🔔 New Hiro Wallet released: [Download `v${{ needs.create-release.outputs.new_version }}` here](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.create-release.outputs.new_version }})

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/blockstack/stacks-wallet/Build)
 [![coverage](https://raw.githubusercontent.com/blockstack/stacks-wallet/gh-pages/badge.svg)](https://blockstack.github.io/stacks-wallet/)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/blockstack/stacks-wallet)](https://github.com/blockstack/stacks-wallet/releases/latest)
 
 [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/blockstack/stacks-wallet)
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "channel": "3.x"
       },
       {
-        "name": "beta",
+        "name": "dev",
         "prerelease": true
       },
       "main"


### PR DESCRIPTION
> [Download the latest build](https://github.com/blockstack/stacks-wallet/actions/runs/1394044228)<!-- Sticky Header Marker -->

Use `dev` as release branch.